### PR TITLE
`ignore` -> `ignore_derivatives`

### DIFF
--- a/src/training_method/hnn_exact_method.jl
+++ b/src/training_method/hnn_exact_method.jl
@@ -7,7 +7,7 @@ function loss_single(::TrainingMethod{HnnExactMethod}, nn::NeuralNetwork{<:Hamil
     sqeuclidean(dH[1],q̇ₙ) + sqeuclidean(dH[2],ṗₙ)
 end
 
-get_loss(::TrainingMethod{HnnExactMethod}, ::AbstractNeuralNetwork{<:HamiltonianNeuralNetwork}, data::TrainingData{<:DataSymbol{<:DerivativePhaseSpaceSymbol}}, args) = (Zygote.ignore_derivative(get_data(data,:q, args...)), Zygote.ignore_derivative(get_data(data,:p, args...)), Zygote.ignore_derivative(get_data(data,:q̇, args...)), Zygote.ignore_derivative(get_data(data,:ṗ, args...)))
+get_loss(::TrainingMethod{HnnExactMethod}, ::AbstractNeuralNetwork{<:HamiltonianNeuralNetwork}, data::TrainingData{<:DataSymbol{<:DerivativePhaseSpaceSymbol}}, args) = (Zygote.ignore_derivatives(get_data(data,:q, args...)), Zygote.ignore_derivatives(get_data(data,:p, args...)), Zygote.ignore_derivatives(get_data(data,:q̇, args...)), Zygote.ignore_derivatives(get_data(data,:ṗ, args...)))
 
 loss(ti::TrainingMethod{HnnExactMethod}, nn::NeuralNetwork{<:HamiltonianNeuralNetwork}, data::TrainingData{<:DataSymbol{<:DerivativePhaseSpaceSymbol}}, index_batch = eachindex(ti, data), params = nn.params) = 
-mapreduce(args->loss_single(Zygote.ignore_derivative(ti), nn, get_loss(ti, nn, data, args)..., params), +, index_batch)
+mapreduce(args->loss_single(Zygote.ignore_derivatives(ti), nn, get_loss(ti, nn, data, args)..., params), +, index_batch)

--- a/src/training_method/hnn_exact_method.jl
+++ b/src/training_method/hnn_exact_method.jl
@@ -7,7 +7,7 @@ function loss_single(::TrainingMethod{HnnExactMethod}, nn::NeuralNetwork{<:Hamil
     sqeuclidean(dH[1],q̇ₙ) + sqeuclidean(dH[2],ṗₙ)
 end
 
-get_loss(::TrainingMethod{HnnExactMethod}, ::AbstractNeuralNetwork{<:HamiltonianNeuralNetwork}, data::TrainingData{<:DataSymbol{<:DerivativePhaseSpaceSymbol}}, args) = (Zygote.ignore(get_data(data,:q, args...)), Zygote.ignore(get_data(data,:p, args...)), Zygote.ignore(get_data(data,:q̇, args...)), Zygote.ignore(get_data(data,:ṗ, args...)))
+get_loss(::TrainingMethod{HnnExactMethod}, ::AbstractNeuralNetwork{<:HamiltonianNeuralNetwork}, data::TrainingData{<:DataSymbol{<:DerivativePhaseSpaceSymbol}}, args) = (Zygote.ignore_derivative(get_data(data,:q, args...)), Zygote.ignore_derivative(get_data(data,:p, args...)), Zygote.ignore_derivative(get_data(data,:q̇, args...)), Zygote.ignore_derivative(get_data(data,:ṗ, args...)))
 
 loss(ti::TrainingMethod{HnnExactMethod}, nn::NeuralNetwork{<:HamiltonianNeuralNetwork}, data::TrainingData{<:DataSymbol{<:DerivativePhaseSpaceSymbol}}, index_batch = eachindex(ti, data), params = nn.params) = 
-mapreduce(args->loss_single(Zygote.ignore(ti), nn, get_loss(ti, nn, data, args)..., params), +, index_batch)
+mapreduce(args->loss_single(Zygote.ignore_derivative(ti), nn, get_loss(ti, nn, data, args)..., params), +, index_batch)

--- a/src/training_method/lnn_exact_method.jl
+++ b/src/training_method/lnn_exact_method.jl
@@ -7,6 +7,6 @@ function loss_single(::TrainingMethod{LnnExactMethod}, nn::AbstractNeuralNetwork
 end
 
 loss(ti::TrainingMethod{<:LnnExactMethod}, nn::AbstractNeuralNetwork{<:LagrangianNeuralNetwork}, data::TrainingData{<:DataSymbol{<:PosVeloAccSymbol}}, index_batch = eachindex(ti, data), params = nn.params) = 
-mapreduce(args->loss_single(Zygote.ignore_derivative(ti), nn, get_loss(ti, nn, data, args)..., params),+, index_batch)
+mapreduce(args->loss_single(Zygote.ignore_derivatives(ti), nn, get_loss(ti, nn, data, args)..., params),+, index_batch)
 
 get_loss(::TrainingMethod{<:LnnExactMethod}, ::AbstractNeuralNetwork{<:LagrangianNeuralNetwork}, data::TrainingData{<:DataSymbol{<:PosVeloAccSymbol}}, args) = (get_data(data, :q,args...), get_data(data, :q̇, args...), get_data(data, :q̈, args...))

--- a/src/training_method/lnn_exact_method.jl
+++ b/src/training_method/lnn_exact_method.jl
@@ -7,6 +7,6 @@ function loss_single(::TrainingMethod{LnnExactMethod}, nn::AbstractNeuralNetwork
 end
 
 loss(ti::TrainingMethod{<:LnnExactMethod}, nn::AbstractNeuralNetwork{<:LagrangianNeuralNetwork}, data::TrainingData{<:DataSymbol{<:PosVeloAccSymbol}}, index_batch = eachindex(ti, data), params = nn.params) = 
-mapreduce(args->loss_single(Zygote.ignore(ti), nn, get_loss(ti, nn, data, args)..., params),+, index_batch)
+mapreduce(args->loss_single(Zygote.ignore_derivative(ti), nn, get_loss(ti, nn, data, args)..., params),+, index_batch)
 
 get_loss(::TrainingMethod{<:LnnExactMethod}, ::AbstractNeuralNetwork{<:LagrangianNeuralNetwork}, data::TrainingData{<:DataSymbol{<:PosVeloAccSymbol}}, args) = (get_data(data, :q,args...), get_data(data, :q̇, args...), get_data(data, :q̈, args...))

--- a/src/training_method/symplectic_euler.jl
+++ b/src/training_method/symplectic_euler.jl
@@ -22,7 +22,7 @@ end
 get_loss(::TrainingMethod{<:SymplecticEuler}, ::AbstractNeuralNetwork{<:HamiltonianNeuralNetwork}, data::TrainingData{<:DataSymbol{<:PhaseSpaceSymbol}}, args) = (get_data(data,:q, args...), get_data(data,:q, next(args...)...), get_data(data,:p, args...), get_data(data,:p,next(args...)...), get_Δt(data))
 
 loss(ti::TrainingMethod{<:SymplecticEuler}, nn::AbstractNeuralNetwork{<:HamiltonianNeuralNetwork}, data::TrainingData{<:DataSymbol{<:PhaseSpaceSymbol}}, index_batch = eachindex(ti, data), params = nn.params) = 
-mapreduce(args->loss_single(Zygote.ignore_derivative(ti), nn, get_loss(ti, nn, data, args)..., params),+, index_batch)
+mapreduce(args->loss_single(Zygote.ignore_derivatives(ti), nn, get_loss(ti, nn, data, args)..., params),+, index_batch)
 
 min_length_batch(::SymplecticEuler) = 2
 

--- a/src/training_method/symplectic_euler.jl
+++ b/src/training_method/symplectic_euler.jl
@@ -22,7 +22,7 @@ end
 get_loss(::TrainingMethod{<:SymplecticEuler}, ::AbstractNeuralNetwork{<:HamiltonianNeuralNetwork}, data::TrainingData{<:DataSymbol{<:PhaseSpaceSymbol}}, args) = (get_data(data,:q, args...), get_data(data,:q, next(args...)...), get_data(data,:p, args...), get_data(data,:p,next(args...)...), get_Δt(data))
 
 loss(ti::TrainingMethod{<:SymplecticEuler}, nn::AbstractNeuralNetwork{<:HamiltonianNeuralNetwork}, data::TrainingData{<:DataSymbol{<:PhaseSpaceSymbol}}, index_batch = eachindex(ti, data), params = nn.params) = 
-mapreduce(args->loss_single(Zygote.ignore(ti), nn, get_loss(ti, nn, data, args)..., params),+, index_batch)
+mapreduce(args->loss_single(Zygote.ignore_derivative(ti), nn, get_loss(ti, nn, data, args)..., params),+, index_batch)
 
 min_length_batch(::SymplecticEuler) = 2
 

--- a/src/training_method/sympnet_basic_method.jl
+++ b/src/training_method/sympnet_basic_method.jl
@@ -8,9 +8,9 @@ function loss_single(::TrainingMethod{BasicSympNetMethod}, nn::AbstractNeuralNet
 end
 
 get_loss(::TrainingMethod{<:BasicSympNetMethod}, ::AbstractNeuralNetwork{<:SympNet}, data::TrainingData{<:DataSymbol{<:PhaseSpaceSymbol}}, args) = 
-(Zygote.ignore_derivative(get_data(data,:q, args...)), Zygote.ignore_derivative(get_data(data,:p, args...)), Zygote.ignore_derivative(get_data(data,:q, next(args...)...)), Zygote.ignore_derivative(get_data(data,:p, next(args...)...)))
+(Zygote.ignore_derivatives(get_data(data,:q, args...)), Zygote.ignore_derivatives(get_data(data,:p, args...)), Zygote.ignore_derivatives(get_data(data,:q, next(args...)...)), Zygote.ignore_derivatives(get_data(data,:p, next(args...)...)))
 
 loss(ti::TrainingMethod{<:BasicSympNetMethod}, nn::AbstractNeuralNetwork{<:SympNet}, data::TrainingData{<:DataSymbol{<:PhaseSpaceSymbol}}, index_batch = eachindex(ti, data), params = nn.params) = 
-mapreduce(args->loss_single(Zygote.ignore_derivative(ti), nn, get_loss(ti, nn, data, args)..., params),+, index_batch)
+mapreduce(args->loss_single(Zygote.ignore_derivatives(ti), nn, get_loss(ti, nn, data, args)..., params),+, index_batch)
 min_length_batch(::BasicSympNetMethod) = 2
 

--- a/src/training_method/sympnet_basic_method.jl
+++ b/src/training_method/sympnet_basic_method.jl
@@ -8,9 +8,9 @@ function loss_single(::TrainingMethod{BasicSympNetMethod}, nn::AbstractNeuralNet
 end
 
 get_loss(::TrainingMethod{<:BasicSympNetMethod}, ::AbstractNeuralNetwork{<:SympNet}, data::TrainingData{<:DataSymbol{<:PhaseSpaceSymbol}}, args) = 
-(Zygote.ignore(get_data(data,:q, args...)), Zygote.ignore(get_data(data,:p, args...)), Zygote.ignore(get_data(data,:q, next(args...)...)), Zygote.ignore(get_data(data,:p, next(args...)...)))
+(Zygote.ignore_derivative(get_data(data,:q, args...)), Zygote.ignore_derivative(get_data(data,:p, args...)), Zygote.ignore_derivative(get_data(data,:q, next(args...)...)), Zygote.ignore_derivative(get_data(data,:p, next(args...)...)))
 
 loss(ti::TrainingMethod{<:BasicSympNetMethod}, nn::AbstractNeuralNetwork{<:SympNet}, data::TrainingData{<:DataSymbol{<:PhaseSpaceSymbol}}, index_batch = eachindex(ti, data), params = nn.params) = 
-mapreduce(args->loss_single(Zygote.ignore(ti), nn, get_loss(ti, nn, data, args)..., params),+, index_batch)
+mapreduce(args->loss_single(Zygote.ignore_derivative(ti), nn, get_loss(ti, nn, data, args)..., params),+, index_batch)
 min_length_batch(::BasicSympNetMethod) = 2
 

--- a/src/training_method/variational_method.jl
+++ b/src/training_method/variational_method.jl
@@ -23,5 +23,5 @@ end
 get_loss(::TrainingMethod{<:VariationalMidPointMethod}, ::AbstractNeuralNetwork{<:LagrangianNeuralNetwork}, data::TrainingData{<:DataSymbol{<:PositionSymbol}}, args) = (get_data(data,:q, args...), get_data(data,:q, next(args...)...), get_data(data,:q,next(next(args...)...)...), get_Δt(data))
 
 loss(ti::TrainingMethod{<:VariationalMidPointMethod}, nn::AbstractNeuralNetwork{<:LagrangianNeuralNetwork}, data::TrainingData{<:DataSymbol{<:PositionSymbol}}, index_batch = eachindex(ti, data), params = nn.params) = 
-mapreduce(args->loss_single(Zygote.ignore_derivative(ti), nn, get_loss(ti, nn, data, args)..., params),+, index_batch)
+mapreduce(args->loss_single(Zygote.ignore_derivatives(ti), nn, get_loss(ti, nn, data, args)..., params),+, index_batch)
 min_length_batch(::VariationalMethod) = 3

--- a/src/training_method/variational_method.jl
+++ b/src/training_method/variational_method.jl
@@ -23,5 +23,5 @@ end
 get_loss(::TrainingMethod{<:VariationalMidPointMethod}, ::AbstractNeuralNetwork{<:LagrangianNeuralNetwork}, data::TrainingData{<:DataSymbol{<:PositionSymbol}}, args) = (get_data(data,:q, args...), get_data(data,:q, next(args...)...), get_data(data,:q,next(next(args...)...)...), get_Δt(data))
 
 loss(ti::TrainingMethod{<:VariationalMidPointMethod}, nn::AbstractNeuralNetwork{<:LagrangianNeuralNetwork}, data::TrainingData{<:DataSymbol{<:PositionSymbol}}, index_batch = eachindex(ti, data), params = nn.params) = 
-mapreduce(args->loss_single(Zygote.ignore(ti), nn, get_loss(ti, nn, data, args)..., params),+, index_batch)
+mapreduce(args->loss_single(Zygote.ignore_derivative(ti), nn, get_loss(ti, nn, data, args)..., params),+, index_batch)
 min_length_batch(::VariationalMethod) = 3


### PR DESCRIPTION
Replaced `ignore` with `ignore_derivatives` (see https://github.com/JuliaGNI/GeometricMachineLearning.jl/issues/85). 

I'm also not quite sure why we need this routine, because `ignore_derivatives` does as the name suggests only compute the forward pass while not outputting the pullback; it should be equivalent to simply calling the function: https://github.com/JuliaDiff/ChainRulesCore.jl/blob/83366a5b2a1415dcae9b39521ae4c8b887bb0d5c/src/ignore_derivatives.jl#L8