### PR TITLE
Add dark mode images for mha and spline and fixed problem with html on github

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,6 +8,9 @@ ENV["GKSwstype"] = "100"
 
 bib = CitationBibliography(joinpath(@__DIR__, "src", "GeometricMachineLearning.bib"))
 
+# if the docs are generated with github actions, then this changes the path; see: https://github.com/JuliaDocs/Documenter.jl/issues/921 
+const buildpath = haskey(ENV, "CI") ? ".." : ""
+
 makedocs(;
     plugins=[bib],
     modules=[GeometricMachineLearning],

--- a/docs/src/Optimizer.md
+++ b/docs/src/Optimizer.md
@@ -6,10 +6,9 @@ Starting from an element of the tangent space $T_Y\mathcal{M}$[^1], we need to p
 
 [^1]: In practice this is obtained by first using an AD routine on a loss function $L$, and then computing the Riemannian gradient based on this. See the section of the [Stiefel manifold](manifolds/stiefel_manifold.md) for an example of this.
 
-
-```@raw html
-<img class="display-light-only" src="tikz/general_optimization_with_boundary.png">
-<img class="display-dark-only" src="tikz/general_optimization_with_boundary_dark.png">
+```@example
+HTML("""<object type="image/svg+xml" class="display-light-only" data=$(joinpath(Main.buildpath, "tikz/general_optimization_with_boundary.png"))></object>""") # hide
+HTML("""<object type="image/svg+xml" class="display-dark-only" data=$(joinpath(Main.buildpath, "tikz/general_optimization_with_boundary_dark.png"))></object>""") # hide
 ```
 
 Here the mapping $\Omega$ is a [horizontal lift](optimizers/manifold_related/horizontal_lift.md) from the tangent space onto the **horizontal component of the Lie algebra at $Y$**. 

--- a/docs/src/architectures/sympnet.md
+++ b/docs/src/architectures/sympnet.md
@@ -16,8 +16,8 @@ SympNets can be viewed as a "symplectic integrator" (see [hairer2006geometric](@
 The tilde in the above equation indicates *predicted data*. The time step between predictions is not a parameter we can choose but is related to the *temporal frequency of the training data*. This means that if data is recorded in an interval of e.g. 0.1 seconds, then this will be the time step of our integrator.
 
 ```@raw html
-<img class="display-light-only" src="../../tikz/sympnet_architecture.png" alt="SympNet Architecture">
-<img class="display-dark-only" src="../../tikz/sympnet_architecture_dark.png" alt="SympNet Architecture">
+<img class="display-light-only" src="../assets/tikz/sympnet_architecture.png" alt="SympNet Architecture">
+<img class="display-dark-only" src="../assets/tikz/sympnet_architecture_dark.png" alt="SympNet Architecture">
 ```
 
 There are two types of SympNet architectures: $LA$-SympNets and $G$-SympNets. 

--- a/docs/src/architectures/sympnet.md
+++ b/docs/src/architectures/sympnet.md
@@ -15,9 +15,9 @@ SympNets can be viewed as a "symplectic integrator" (see [hairer2006geometric](@
 ```
 The tilde in the above equation indicates *predicted data*. The time step between predictions is not a parameter we can choose but is related to the *temporal frequency of the training data*. This means that if data is recorded in an interval of e.g. 0.1 seconds, then this will be the time step of our integrator.
 
-```@raw html
-<img class="display-light-only" src="../assets/tikz/sympnet_architecture.png" alt="SympNet Architecture">
-<img class="display-dark-only" src="../assets/tikz/sympnet_architecture_dark.png" alt="SympNet Architecture">
+```@example
+HTML("""<object type="image/svg+xml" class="display-light-only" data=$(joinpath(Main.buildpath, "../tikz/sympnet_architecture.png"))></object>""") # hide
+HTML("""<object type="image/svg+xml" class="display-dark-only" data=$(joinpath(Main.buildpath, "../tikz/sympnet_architecture_dark.png"))></object>""") # hide
 ```
 
 There are two types of SympNet architectures: $LA$-SympNets and $G$-SympNets. 

--- a/docs/src/layers/multihead_attention_layer.md
+++ b/docs/src/layers/multihead_attention_layer.md
@@ -19,7 +19,10 @@ where $n$ is the dimension of the vectors in $V$, $Q$ and $K$. The softmax activ
 
 The transformer contains a **self-attention mechanism**, i.e. takes an input $X$ and then transforms it linearly to $V$, $Q$ and $K$, i.e. $V = P^VX$, $Q = P^QX$ and $K = P^KX$. What distinguishes the multihead attention layer from the singlehead attention layer, is that there is not just one $P^V$, $P^Q$ and $P^K$, but there are several: one for each **head** of the multihead attention layer. After computing the individual values, queries and vectors, and after applying the softmax, the outputs are then concatenated together in order to obtain again an array that is of the same size as the input array:
 
-![](../tikz/mha.png)
+```@example
+HTML("""<object type="image/svg+xml" class="display-light-only" data=$(joinpath(Main.buildpath, "../tikz/mha.png"))></object>""") # hide
+HTML("""<object type="image/svg+xml" class="display-dark-only" data=$(joinpath(Main.buildpath, "../tikz/mha_dark.png"))></object>""") # hide
+```
 
 Here the various $P$ matrices can be interpreted as being projections onto lower-dimensional subspaces, hence the designation by the letter $P$. Because of this interpretation as projection matrices onto smaller spaces that should **capture features in the input data** it makes sense to constrain these elements to be part of the Stiefel manifold.   
 

--- a/docs/src/tikz/Makefile
+++ b/docs/src/tikz/Makefile
@@ -24,11 +24,10 @@ png:
 	pdftocairo  -png -r 150 -transp -singlefile  transformer_encoder.pdf		        		transformer_encoder   
 	pdftocairo  -png -r 150 -transp -singlefile  third_degree_spline.pdf	           			third_degree_spline     
 	pdftocairo  -png -r 150 -transp -singlefile  third_degree_spline_dark.pdf	           		third_degree_spline_dark       
-	mkdir -p ../assets/tikz
-	pdftocairo	-png -r 150 -transp -singlefile	 sympnet_architecture.pdf						../assets/tikz/sympnet_architecture
-	pdftocairo	-png -r 150 -transp -singlefile	 sympnet_architecture_dark.pdf					../assets/tikz/sympnet_architecture_dark
-	pdftocairo 	-png -r 150 -transp -singlefile  structs_visualization.pdf						structs_visualization
-	pdftocairo 	-png -r 150 -transp -singlefile  structs_visualization_dark.pdf					structs_visualization_dark
+	pdftocairo	-png -r 200 -transp -singlefile	 sympnet_architecture.pdf						sympnet_architecture
+	pdftocairo	-png -r 200 -transp -singlefile	 sympnet_architecture_dark.pdf					sympnet_architecture_dark
+	pdftocairo 	-png -r 100 -transp -singlefile  structs_visualization.pdf						structs_visualization
+	pdftocairo 	-png -r 100 -transp -singlefile  structs_visualization_dark.pdf					structs_visualization_dark
 	pdftocairo 	-png -r 150 -transp -singlefile	 logo.pdf										logo 
 	pdftocairo  -png -r 150 -transp -singlefile  symplectic_autoencoder.pdf						symplectic_autoencoder
 	pdftocairo  -png -r 150 -transp -singlefile  solution_manifold_2.pdf						solution_manifold_2

--- a/docs/src/tikz/Makefile
+++ b/docs/src/tikz/Makefile
@@ -5,6 +5,7 @@ pdf:
 	xelatex -shell-escape general_optimization_with_boundary_dark
 	xelatex -shell-escape transformer_encoder
 	xelatex -shell-escape third_degree_spline
+	xelatex -shell-escape third_degree_spline_dark
 	xelatex -shell-escape sympnet_architecture
 	xelatex -shell-escape sympnet_architecture_dark
 	xelatex -shell-escape structs_visualization
@@ -13,6 +14,7 @@ pdf:
 	xelatex -shell-escape symplectic_autoencoder
 	xelatex -shell-escape solution_manifold_2
 	xelatex -shell-escape mha
+	xelatex -shell-escape mha_dark
 
 png:
 	pdftocairo  -png -r 150 -transp -singlefile  adam_optimizer.pdf               	 			adam_optimizer              
@@ -20,15 +22,18 @@ png:
 	pdftocairo  -png -r 150 -transp -singlefile  general_optimization_with_boundary.pdf 		general_optimization_with_boundary              
 	pdftocairo  -png -r 150 -transp -singlefile  general_optimization_with_boundary_dark.pdf	general_optimization_with_boundary_dark          
 	pdftocairo  -png -r 150 -transp -singlefile  transformer_encoder.pdf		        		transformer_encoder   
-	pdftocairo  -png -r 150 -transp -singlefile  third_degree_spline.pdf	           			third_degree_spline          
-	pdftocairo	-png -r 150 -transp -singlefile	 sympnet_architecture.pdf						sympnet_architecture
-	pdftocairo	-png -r 150 -transp -singlefile	 sympnet_architecture_dark.pdf					sympnet_architecture_dark
+	pdftocairo  -png -r 150 -transp -singlefile  third_degree_spline.pdf	           			third_degree_spline     
+	pdftocairo  -png -r 150 -transp -singlefile  third_degree_spline_dark.pdf	           		third_degree_spline_dark       
+	mkdir -p ../assets/tikz
+	pdftocairo	-png -r 150 -transp -singlefile	 sympnet_architecture.pdf						../assets/tikz/sympnet_architecture
+	pdftocairo	-png -r 150 -transp -singlefile	 sympnet_architecture_dark.pdf					../assets/tikz/sympnet_architecture_dark
 	pdftocairo 	-png -r 150 -transp -singlefile  structs_visualization.pdf						structs_visualization
 	pdftocairo 	-png -r 150 -transp -singlefile  structs_visualization_dark.pdf					structs_visualization_dark
 	pdftocairo 	-png -r 150 -transp -singlefile	 logo.pdf										logo 
 	pdftocairo  -png -r 150 -transp -singlefile  symplectic_autoencoder.pdf						symplectic_autoencoder
 	pdftocairo  -png -r 150 -transp -singlefile  solution_manifold_2.pdf						solution_manifold_2
 	pdftocairo  -png -r 150 -transp -singlefile  mha.pdf 										mha
+	pdftocairo  -png -r 150 -transp -singlefile  mha_dark.pdf 									mha_dark
 
 logo:
 	xelatex -shell-escape logo_with_name

--- a/docs/src/tikz/mha_dark.tex
+++ b/docs/src/tikz/mha_dark.tex
@@ -1,0 +1,45 @@
+\documentclass[tikz]{standalone}
+
+\usepackage{xcolor}
+\definecolor{morange}{RGB}{255,127,14}
+\definecolor{mblue}{RGB}{31,119,180}
+\definecolor{mred}{RGB}{214,39,40}
+\definecolor{mpurple}{RGB}{148,103,189}
+\definecolor{mgreen}{RGB}{44,160,44}
+
+\usepackage{tikz}
+\usetikzlibrary{positioning}
+\usetikzlibrary{calc}
+\usetikzlibrary{fit}
+\usetikzlibrary{shadows}
+\usetikzlibrary{decorations}
+
+\begin{document}
+\begin{tikzpicture}[module/.style={draw, very thick, rounded corners, minimum width=15ex},
+    attmodule/.style={module, fill=morange!30},
+    linear/.style={module, fill=mblue!30},
+    concat/.style={module, fill=mpurple!30},
+    arrow/.style={-stealth, thick, rounded corners},
+]
+\node (input) {\color{white}Input};
+\node[above of=input, linear, align=center, double copy shadow={opacity=.5, shadow yshift=1.7ex, shadow xshift=1.2ex}] (linear_center) {Linear};
+\node[left of=linear_center, linear, align=center, xshift=-1.5cm, double copy shadow={opacity=.5, shadow yshift=1.7ex, shadow xshift=1.2ex}] (linear_left) {Linear};
+\node[right of=linear_center, linear, align=center, xshift=1.5cm, double copy shadow={opacity=.5, shadow yshift=1.7ex, shadow xshift=1.2ex}] (linear_right) {Linear};
+\node[above of=linear_center, attmodule, align=center, yshift=.5cm, double copy shadow={opacity=.5, shadow yshift=1.7ex, shadow xshift=1.2ex}] (sha) {Attention Mechanism};
+\node[above of=sha, concat, yshift=.4cm] (concat) {Concatenate};
+\node[above of=concat] (output) {\color{white}Output};
+
+% to have the shadows displayed in the final pdf
+\node[right of=linear_right, xshift=.4cm] (right_of_linear_right) {};
+
+\draw[arrow, double copy shadow={opacity=.5, shadow yshift=1.7ex, shadow xshift=1.2ex, color=white}, color=white] (input) -- (linear_left);
+\draw[arrow, double copy shadow={opacity=.2, shadow yshift=1.7ex, shadow xshift=1.2ex, color=white}, color=white] (input) -- (linear_center); 
+\draw[arrow, double copy shadow={opacity=.5, shadow yshift=1.7ex, shadow xshift=1.2ex, color=white}, color=white] (input) -- (linear_right);
+\draw[arrow, double copy shadow={opacity=.2, shadow yshift=1.7ex, shadow xshift=1.2ex, color=white}, color=white] (linear_left) -- (sha.south west);
+\draw[arrow, double copy shadow={opacity=.2, shadow yshift=1.7ex, shadow xshift=1.2ex, color=white}, color=white] (linear_center) -- (sha.south);
+\draw[arrow, double copy shadow={opacity=.5, shadow yshift=1.7ex, shadow xshift=1.2ex, color=white}, color=white] (linear_right) -- (sha.south east); 
+\draw[arrow, double copy shadow={opacity=.2, shadow yshift=1.7ex, shadow xshift=1.2ex, color=white}, color=white] (sha) -- (concat.south);
+\draw[arrow, color=white] (concat) -- (output);
+
+\end{tikzpicture}
+\end{document}

--- a/docs/src/tikz/sympnet_architecture.tex
+++ b/docs/src/tikz/sympnet_architecture.tex
@@ -31,7 +31,7 @@
 \node[ffnnmodule, right of=qp0, align=center, xshift=5ex] (qp1) {$q^{(1)}$ \\ \\ $p^{(1)}$};
 \node[ffnnmodule, right of=qp1, align=center, xshift=5ex] (qp2) {$q^{(2)}$ \\ \\ $p^{(2)}$};
 \node[right of=qp2, align=center, xshift=5ex] (dots) { \\ $\cdots$ \\ };
-\node[right of=dots, ffnnmodule, align=center, xshift=5ex] (qpn) {$q^{(k+1)}$ \\ \\ $p^{(k+1)}$};
+\node[right of=dots, ffnnmodule, align=center, xshift=7ex] (qpn) {$q^{(k+1)}$ \\ \\ $p^{(k+1)}$};
 
 \coordinate[right of=qp0, xshift=1.5ex] (leftofqp1);
 \coordinate[right of=dots] (rightofdots);

--- a/docs/src/tikz/sympnet_architecture_dark.tex
+++ b/docs/src/tikz/sympnet_architecture_dark.tex
@@ -31,7 +31,7 @@
 \node[ffnnmodule, right of=qp0, align=center, xshift=5ex] (qp1) {$q^{(1)}$ \\ \\ $p^{(1)}$};
 \node[ffnnmodule, right of=qp1, align=center, xshift=5ex] (qp2) {$q^{(2)}$ \\ \\ $p^{(2)}$};
 \node[right of=qp2, align=center, xshift=5ex] (dots) { \\ {\color{white}$\cdots$} \\ };
-\node[right of=dots, ffnnmodule, align=center, xshift=5ex] (qpn) {$q^{(k+1)}$ \\ \\ $p^{(k+1)}$};
+\node[right of=dots, ffnnmodule, align=center, xshift=7ex] (qpn) {$q^{(k+1)}$ \\ \\ $p^{(k+1)}$};
 
 \coordinate[right of=qp0, xshift=1.5ex] (leftofqp1);
 \coordinate[right of=dots] (rightofdots);

--- a/docs/src/tikz/third_degree_spline_dark.tex
+++ b/docs/src/tikz/third_degree_spline_dark.tex
@@ -1,0 +1,51 @@
+\documentclass[crop, tikz]{standalone}
+
+\usepackage{tikz}
+\usepackage{pgfplots}
+\usepackage{amsmath}
+\usepackage{amssymb}
+\usepackage[mode=buildnew]{standalone}
+
+\usepackage{xcolor}
+
+
+\usetikzlibrary{positioning}
+\usetikzlibrary{calc}
+\usetikzlibrary{fit}
+%\usepackage{nicematrix}
+
+\tikzset{set/.style={draw,circle,inner sep=0pt,align=center}}
+
+\definecolor{mred}{RGB}{214,39,40}
+\definecolor{mgreen}{RGB}{44,160,44}
+
+\begin{document}
+%\begin{tikzpicture}
+%    \draw[domain=0:1,smooth,variable=\s]plot (\s, 1 - 3/2 * \s^2 + 3/4 * \s^3);
+%    \draw[domain=1:2,smooth,variable=\s]plot (\s, (2 - \s)^3 / 4);
+%\end{tikzpicture}
+\begin{tikzpicture}
+    \begin{axis}[
+        axis lines = left,
+        xlabel = \(s\),
+        ylabel = {\(h(s)\)},
+        color = white,
+    ]
+    % below the first part of the spline is defined
+    \addplot [
+        domain=0:1, 
+        samples=100, 
+        color=mred,
+    ]
+    {1 - 3/2 * x^2 + 3/4 * x^3};
+    % the second part of the spline
+    \addplot [
+        domain=1:2, 
+        samples=100, 
+        color=mred,
+        ]
+        {(2 - x)^3 / 4};
+    
+    \end{axis}
+    \end{tikzpicture}
+\end{document}

--- a/docs/src/tutorials/linear_wave_equation.md
+++ b/docs/src/tutorials/linear_wave_equation.md
@@ -56,7 +56,11 @@ h(s)  = \begin{cases}
 
 Plotted on the relevant domain it looks like this: 
 
-![](../tikz/third_degree_spline.png)
+```@example
+HTML("""<object type="image/svg+xml" class="display-light-only" data=$(joinpath(Main.buildpath, "../tikz/third_degree_spline.png"))></object>""") # hide
+HTML("""<object type="image/svg+xml" class="display-dark-only" data=$(joinpath(Main.buildpath, "../tikz/third_degree_spline_dark.png"))></object>""") # hide
+```
+
 
 Taking the above function $h(s)$ as a starting point, the initial conditions for the linear wave equations will now be constructed under the following considerations: 
 - the initial condition (i.e. the shape of the wave) should depend on the parameter of the vector field, i.e. $u_0(\mu)(\omega) = h(s(\omega, \mu))$.

--- a/docs/src/tutorials/sympnet_tutorial.md
+++ b/docs/src/tutorials/sympnet_tutorial.md
@@ -49,10 +49,11 @@ The loss function described in the [theory section](../architectures/sympnet.md)
 
 ## Data Structures in `GeometricMachineLearning.jl`
 
-```@raw html
-<img class="display-light-only" src="../tikz/structs_visualization.png" alt="Structs Visualization">
-<img class="display-dark-only" src="../tikz/structs_visualization_dark.png" alt="Structs Visualization">
+```@example
+HTML("""<object type="image/svg+xml" class="display-light-only" data=$(joinpath(Main.buildpath, "../tikz/structs_visualization.png"))></object>""") # hide
+HTML("""<object type="image/svg+xml" class="display-dark-only" data=$(joinpath(Main.buildpath, "../tikz/structs_visualization_dark.png"))></object>""") # hide
 ```
+
 
 ## Examples
 


### PR DESCRIPTION
Implemented dark mode versions for `mha` and `third_degree_spline` and the fix from https://github.com/JuliaDocs/Documenter.jl/issues/921. 