### PR TITLE
Transformer integrator

### DIFF
--- a/docs/src/tutorials/sympnet_tutorial.md
+++ b/docs/src/tutorials/sympnet_tutorial.md
@@ -173,8 +173,8 @@ ics = (q=qp_data.q[:,1], p=qp_data.p[:,1])
 steps_to_plot = 200
 
 #predictions
-la_trajectory = Iterate_Sympnet(la_nn, ics; n_points = steps_to_plot)
-g_trajectory = Iterate_Sympnet(g_nn, ics; n_points = steps_to_plot)
+la_trajectory = iterate(la_nn, ics; n_points = steps_to_plot)
+g_trajectory =  iterate(g_nn, ics; n_points = steps_to_plot)
 
 using Plots
 p2 = plot(qp_data.q'[1:steps_to_plot], qp_data.p'[1:steps_to_plot], label="training data")

--- a/src/GeometricMachineLearning.jl
+++ b/src/GeometricMachineLearning.jl
@@ -158,7 +158,7 @@ module GeometricMachineLearning
     export PSDLayer
     export MultiHeadAttention
     export VolumePreservingAttention
-    export ResNet
+    export ResNetLayer
     export Transformer
     export Classification
     export VolumePreservingLowerLayer
@@ -246,6 +246,9 @@ module GeometricMachineLearning
 
     #INCLUDE ARCHITECTURES
     include("architectures/neural_network_integrator.jl")
+    include("architectures/resnet.jl")
+    include("architectures/transformer_integrator.jl")
+    include("architectures/regular_transformer_integrator.jl")
     include("architectures/sympnet.jl")
     include("architectures/autoencoder.jl")
     include("architectures/fixed_width_network.jl")
@@ -265,6 +268,8 @@ module GeometricMachineLearning
     export RecurrentNeuralNetwork
     export LSTMNeuralNetwork
     export ClassificationTransformer
+    export ResNet
+    export RegularTransformerIntegrator
     export VolumePreservingFeedForward
 
     export train!, apply!, jacobian!

--- a/src/architectures/regular_transformer_integrator.jl
+++ b/src/architectures/regular_transformer_integrator.jl
@@ -3,7 +3,7 @@ The regular transformer used as an integrator (multi-step method).
 
 The constructor is called with the following arguments: 
 - `sys_dim::Int`
-- `transformer_dim::Int`: the defualt is `transformer_dim = sys_dim`.
+- `transformer_dim::Int`: the default is `transformer_dim = sys_dim`.
 - `n_blocks::Int`: The default is `1`.
 - `n_heads::Int`: the number of heads in the multihead attentio layer (default is `n_heads = sys_dim`)
 - `L::Int` the number of transformer blocks (default is `L = 2`).

--- a/src/architectures/regular_transformer_integrator.jl
+++ b/src/architectures/regular_transformer_integrator.jl
@@ -1,0 +1,42 @@
+@doc raw"""
+The regular transformer used as an integrator (multi-step method). 
+
+The constructor is called with the following arguments: 
+- `sys_dim::Int`
+- `transformer_dim::Int`: the defualt is `transformer_dim = sys_dim`.
+- `n_blocks::Int`: The default is `1`.
+- `n_heads::Int`: the number of heads in the multihead attentio layer (default is `n_heads = sys_dim`)
+- `L::Int` the number of transformer blocks (default is `L = 2`).
+- `upscaling_activation`: by default identity
+- `resnet_activation`: by default tanh
+- `add_connection:Bool=true` (keyword argument): if the input should be added to the output.
+"""
+struct RegularTransformerIntegrator{AT1, AT2} <: TransformerIntegrator
+    sys_dim::Int 
+    transformer_dim::Int 
+    n_heads::Int
+    n_blocks::Int
+    L::Int
+    upsacling_activation::AT1
+    resnet_activation::AT2
+    add_connection::Bool
+end
+
+# function RegularTransformerIntegrator(sys_dim::Int, transformer_dim::Int = sys_dim, n_heads::Int = sys_dim, n_blocks = 1, L::Int = 2, upscaling_activation = identity, resnet_activation = tanh; add_connection::Bool = true)
+#     RegularTransformerIntegrator{typeof(upscaling_activation), typeof(resnet_activation)}(sys_dim, transformer_dim, n_heads, n_blocks, L, upscaling_activation, resnet_activation, add_connection)
+# end
+
+function RegularTransformerIntegrator(sys_dim::Int, transformer_dim::Int = sys_dim, n_heads::Int = sys_dim; n_blocks = 1, L::Int = 2, upscaling_activation = identity, resnet_activation = tanh, add_connection::Bool = true)
+    RegularTransformerIntegrator(sys_dim, transformer_dim, n_heads, n_blocks, L, upscaling_activation, resnet_activation, add_connection)
+end
+
+function Chain(arch::RegularTransformerIntegrator)
+    layers = arch.sys_dim == arch.transformer_dim ? () : (Dense(arch.sys_dim, arch.transformer_dim, arch.upsacling_activation), )
+    for _ in 1:arch.L 
+        layers = (layers..., MultiHeadAttention(arch.transformer_dim, arch.n_heads; add_connection = arch.add_connection))
+        layers = (layers..., Chain(ResNet(arch.transformer_dim, arch.n_blocks, arch.resnet_activation)).layers...)
+    end
+    layers = arch.sys_dim == arch.transformer_dim ? layers : (layers..., Dense(arch.transformer_dim, arch.sys_dim, identity))
+
+    Chain(layers...)
+end

--- a/src/architectures/resnet.jl
+++ b/src/architectures/resnet.jl
@@ -1,0 +1,18 @@
+struct ResNet{AT} <: NeuralNetworkIntegrator
+    sys_dim::Int 
+    n_blocks::Int 
+    activation::AT
+end
+
+function Chain(arch::ResNet{AT}) where AT
+    layers = ()
+    for _ in 1:arch.n_blocks 
+        # nonlinear layers
+        layers = (layers..., ResNetLayer(arch.sys_dim, arch.activation; use_bias=true))
+    end
+
+    # linear layers for the output
+    layers = (layers..., ResNetLayer(arch.sys_dim, identity; use_bias=true))
+
+    Chain(layers...)
+end

--- a/src/architectures/transformer_integrator.jl
+++ b/src/architectures/transformer_integrator.jl
@@ -1,0 +1,69 @@
+@doc raw"""
+Encompasses various transformer architectures, such as the structure-preserving transformer and the linear symplectic transformer. 
+"""
+abstract type TransformerIntegrator <: Architecture end
+
+struct DummyTransformer <: TransformerIntegrator 
+    seq_length::Int
+end
+
+@doc raw"""
+This function computes a trajectory for a Transformer that has already been trained for valuation purposes.
+
+It takes as input: 
+- `nn`: a `NeuralNetwork` (that has been trained).
+- `ics`: initial conditions (a matrix in ``\mathbb{R}^{2n\times\mathtt{seq\_length}}`` or `NamedTuple` of two matrices in ``\mathbb{R}^{n\times\mathtt{seq\_length}}``)
+- `n_points::Int=100` (keyword argument): The number of steps for which we run the prediction. 
+"""
+function Base.iterate(nn::NeuralNetwork{<:TransformerIntegrator}, ics::NamedTuple{(:q, :p), Tuple{AT, AT}}; n_points::Int = 100, prediction_window::Union{Nothing, Int} = 1) where {T, AT<:AbstractMatrix{T}}
+
+    seq_length = nn.architecture.seq_length
+
+    n_dim = size(ics.q, 1)
+    backend = KernelAbstractions.get_backend(ics.q)
+
+    n_iterations = Int(ceil((n_points - seq_length) / prediction_window))
+    # Array to store the predictions
+    q_valuation = KernelAbstractions.allocate(backend, T, n_dim, seq_length + n_iterations * prediction_window)
+    p_valuation = KernelAbstractions.allocate(backend, T, n_dim, seq_length + n_iterations * prediction_window)
+    
+    # Initialisation
+    q_valuation[:,1:seq_length] = ics.q
+    p_valuation[:,1:seq_length] = ics.p
+    
+    # iteration in phase space
+    @views for i in 1:n_iterations
+        start_index = (i - 1) * prediction_window + 1
+        @views qp_temp = (q = q_valuation[:, start_index:(start_index + seq_length - 1)], p = p_valuation[:, start_index:(start_index + seq_length - 1)]) 
+        qp_prediction = nn(qp_temp)
+        q_valuation[seq_length + (i - 1) * prediction_window, seq_length + i * prediction_window] = qp_prediction.q[:, (seq_length - prediction_window + 1):end]
+        p_valuation[seq_length + (i - 1) * prediction_window, seq_length + i * prediction_window] = qp_prediction.p[:, (seq_length - prediction_window + 1):end]
+    end
+
+    (q=q_valuation[:, 1:n_points], p=p_valuation[:, 1:n_points])
+end
+
+function Base.iterate(nn::NeuralNetwork{<:TransformerIntegrator}, ics::AT; n_points::Int = 100, prediction_window::Union{Nothing, Int} = 1) where {T, AT<:AbstractMatrix{T}}
+
+    seq_length = typeof(nn.architecture) <: RegularTransformerIntegrator ? prediction_window : nn.architecture.seq_length
+
+    n_dim = size(ics, 1)
+    backend = KernelAbstractions.get_backend(ics)
+
+    n_iterations = Int(ceil((n_points - seq_length) / prediction_window))
+    # Array to store the predictions
+    valuation = KernelAbstractions.allocate(backend, T, n_dim, seq_length + n_iterations * prediction_window)
+    
+    # Initialisation
+    valuation[:,1:seq_length] = ics
+    
+    # iteration in phase space
+    @views for i in 1:n_iterations
+        start_index = (i - 1) * prediction_window + 1
+        temp = valuation[:, start_index:(start_index + seq_length - 1)]
+        prediction = nn(copy(temp))
+        valuation[:, (seq_length + (i - 1) * prediction_window + 1):(seq_length + i * prediction_window)] = prediction[:, (seq_length - prediction_window + 1):end]
+    end
+
+    valuation[:, 1:n_points]
+end

--- a/src/architectures/transformer_integrator.jl
+++ b/src/architectures/transformer_integrator.jl
@@ -14,8 +14,9 @@ It takes as input:
 - `nn`: a `NeuralNetwork` (that has been trained).
 - `ics`: initial conditions (a matrix in ``\mathbb{R}^{2n\times\mathtt{seq\_length}}`` or `NamedTuple` of two matrices in ``\mathbb{R}^{n\times\mathtt{seq\_length}}``)
 - `n_points::Int=100` (keyword argument): The number of steps for which we run the prediction. 
+- `prediction_window::Int=size(ics.q, 2)`: The prediction window (i.e. the number of steps we predict into the future) is equal to the sequence length (i.e. the number of input time steps) by default.  
 """
-function Base.iterate(nn::NeuralNetwork{<:TransformerIntegrator}, ics::NamedTuple{(:q, :p), Tuple{AT, AT}}; n_points::Int = 100, prediction_window::Union{Nothing, Int} = 1) where {T, AT<:AbstractMatrix{T}}
+function Base.iterate(nn::NeuralNetwork{<:TransformerIntegrator}, ics::NamedTuple{(:q, :p), Tuple{AT, AT}}; n_points::Int = 100, prediction_window::Union{Nothing, Int}=size(ics.q, 2)) where {T, AT<:AbstractMatrix{T}}
 
     seq_length = nn.architecture.seq_length
 
@@ -43,7 +44,7 @@ function Base.iterate(nn::NeuralNetwork{<:TransformerIntegrator}, ics::NamedTupl
     (q=q_valuation[:, 1:n_points], p=p_valuation[:, 1:n_points])
 end
 
-function Base.iterate(nn::NeuralNetwork{<:TransformerIntegrator}, ics::AT; n_points::Int = 100, prediction_window::Union{Nothing, Int} = 1) where {T, AT<:AbstractMatrix{T}}
+function Base.iterate(nn::NeuralNetwork{<:TransformerIntegrator}, ics::AT; n_points::Int = 100, prediction_window::Union{Nothing, Int} = size(ics, 2)) where {T, AT<:AbstractMatrix{T}}
 
     seq_length = typeof(nn.architecture) <: RegularTransformerIntegrator ? prediction_window : nn.architecture.seq_length
 

--- a/src/arrays/symplectic.jl
+++ b/src/arrays/symplectic.jl
@@ -12,23 +12,54 @@ Returns a symplectic matrix of size 2n x 2n
 \end{pmatrix}
 ```
 """
-function SymplecticPotential(backend, n2::Int, T::DataType=Float64)
+struct SymplecticPotential{T, AT} <: AbstractMatrix{T}
+    J::AT
+    n::Int
+end
+
+Base.getindex(𝕁::SymplecticPotential, i, j) = getindex(𝕁.J, i, j)
+
+Base.size(𝕁::SymplecticPotential) = size(𝕁.J)
+
+function SymplecticPotential(backend::Backend, n2::Int, T::DataType)
     @assert iseven(n2)
     n = n2÷2
     J = KernelAbstractions.zeros(backend, T, 2*n, 2*n)
     assign_ones_for_symplectic_potential! = assign_ones_for_symplectic_potential_kernel!(backend)
-    assign_ones_for_symplectic_potential!(J, n, ndrange=n)
-    J
+    assign_ones_for_symplectic_potential!(J, n, ndrange=n2)
+    
+    SymplecticPotential{T, typeof(J)}(J, n)
 end
 
-SymplecticPotential(n::Int, T::DataType=Float64) = SymplecticPotential(CPU(), n, T)
-SymplecticPotential(bakend, T::DataType, n::Int) = SymplecticPotential(backend, n, T)
+SymplecticPotential(n2::Int, T::DataType) = SymplecticPotential(CPU(), n2, T)
 
-SymplecticPotential(T::DataType, n::Int) = SymplecticPotential(n, T)
+SymplecticPotential(n2::Int) = SymplecticPotential(n2, Float64)
+
+SymplecticPotential(backend::Backend, n2::Int) = SymplecticPotential(backend, n2, Float32)
+
+SymplecticPotential(backend::CPU, n2::Int) = SymplecticPotential(backend, n2, Float64)
 
 @kernel function assign_ones_for_symplectic_potential_kernel!(J::AbstractMatrix{T}, n::Int) where T
     i = @index(Global)
     J[map_index_for_symplectic_potential(i, n)...] = i ≤ n ? one(T) : -one(T)
+end
+
+Base.:*(𝕁::SymplecticPotential{T}, v::NamedTuple{(:q, :p), Tuple{AT, AT}}) where {T, AT <: AbstractVecOrMat{T}} = (q = v.p, p = -v.q)
+
+function _vcat(v::NamedTuple{(:q, :p), Tuple{AT, AT}}) where {AT <: AbstractArray}
+    vcat(v.q, v.p)
+end
+
+Base.:*(𝕁::SymplecticPotential{T}, v::AbstractVector{T}) where T = _vcat(𝕁 * assign_q_and_p(v, 𝕁.n))
+Base.:*(𝕁::SymplecticPotential{T}, v::AbstractMatrix{T}) where T = _vcat(𝕁 * assign_q_and_p(v, 𝕁.n))
+
+
+function (𝕁::SymplecticPotential{T})(v₁::NT, v₂::NT) where {T, AT <: AbstractVector{T}, NT <: NamedTuple{(:q, :p), Tuple{AT, AT}}}
+    v₁.q' * v₂.p - v₁.p' * v₂.q
+end
+
+function (𝕁::SymplecticPotential{T})(v₁::AbstractVector{T}, v₂::AbstractVector{T}) where T 
+    𝕁(assign_q_and_p(v₁, 𝕁.n), assign_q_and_p(v₂, 𝕁.n))
 end
 
 """
@@ -36,8 +67,8 @@ This assigns the right index for the symplectic potential. To be used with `assi
 """
 function map_index_for_symplectic_potential(i::Int, n::Int)
     if i ≤ n
-        return (i, i+n)
+        return (i, i + n)
     else
-        return (i, i-n)
+        return (i, i - n)
     end
 end

--- a/src/layers/multi_head_attention.jl
+++ b/src/layers/multi_head_attention.jl
@@ -85,7 +85,7 @@ function compute_output_of_mha(d::MultiHeadAttention{M, M}, x::AbstractMatrix{T}
     output = typeof(x)(zeros(T, 0, input_length))
     for i in 1:d.n_heads
         key = Symbol("head_"*string(i))
-        output = vcat(output, ps.PV[key]'*x*softmax((ps.PQ[key]'*x)'*(ps.PK[key]'*x)/T(sqrt(dim))))
+        output = vcat(output, ps.PV[key]' * x * softmax((ps.PQ[key]' * x)' * (ps.PK[key]' * x) / T(sqrt(dim))))
     end
     output
 end
@@ -111,7 +111,6 @@ function compute_output_of_mha(d::MultiHeadAttention{M, M}, x::AbstractArray{T, 
 
         single_head_output = tensor_tensor_mul(V_tensor, softmax(QK_tensor/T(sqrt(dim))))
         output = vcat(output, single_head_output) 
-        # KernelAbstractions.synchronize(backend)
     end
     output
 end
@@ -125,9 +124,7 @@ function (d::MultiHeadAttention{M, M, Stiefel, Retraction, false})(x::AbstractAr
 end
 
 import ChainRules
-"""
-This has to be extended to tensors; you should probably do a PR in ChainRules for this.
-"""
+# type pyracy! 
 function ChainRules._adjoint_mat_pullback(y::AbstractArray{T, 3}, proj) where T 
     (NoTangent(), proj(tensor_transpose(y)))
 end

--- a/src/layers/resnet.jl
+++ b/src/layers/resnet.jl
@@ -1,12 +1,12 @@
-struct ResNet{M, N, use_bias, F1} <: AbstractExplicitLayer{M, N}
+struct ResNetLayer{M, N, use_bias, F1} <: AbstractExplicitLayer{M, N}
     activation::F1
 end
 
-function ResNet(dim::IT, activation=identity; use_bias::Bool=true) where {IT<:Int}
-    return ResNet{dim, dim, use_bias, typeof(activation)}(activation)
+function ResNetLayer(dim::IT, activation=identity; use_bias::Bool=true) where {IT<:Int}
+    return ResNetLayer{dim, dim, use_bias, typeof(activation)}(activation)
 end
 
-function initialparameters(::ResNet{M, M, use_bias}, backend::KernelAbstractions.Backend, T::Type; rng::Random.AbstractRNG=Random.default_rng(), init_weight = GlorotUniform(), init_bias = ZeroInitializer()) where {M, use_bias}
+function initialparameters(::ResNetLayer{M, M, use_bias}, backend::KernelAbstractions.Backend, T::Type; rng::Random.AbstractRNG=Random.default_rng(), init_weight = GlorotUniform(), init_bias = ZeroInitializer()) where {M, use_bias}
     if use_bias
         weight = KernelAbstractions.allocate(backend, T, M, M)
         bias = KernelAbstractions.allocate(backend, T, M)
@@ -21,23 +21,23 @@ function initialparameters(::ResNet{M, M, use_bias}, backend::KernelAbstractions
     end
 end
 
-function parameterlength(::ResNet{M, M, use_bias}) where {M, use_bias}
+function parameterlength(::ResNetLayer{M, M, use_bias}) where {M, use_bias}
     return use_bias ? M * (M + 1) : M * M
 end
 
-@inline function (d::ResNet{M, M, true})(x::AbstractVecOrMat, ps::NamedTuple) where {M}
+@inline function (d::ResNetLayer{M, M, true})(x::AbstractVecOrMat, ps::NamedTuple) where {M}
     return x + d.activation.(ps.weight * x .+ ps.bias)
 end
 
-@inline function (d::ResNet{M, M, false})(x::AbstractVecOrMat, ps::NamedTuple) where {M}
+@inline function (d::ResNetLayer{M, M, false})(x::AbstractVecOrMat, ps::NamedTuple) where {M}
     return x + d.activation.(ps.weight * x)
 end
 
-@inline function (d::ResNet{M, M, false})(x::AbstractArray{T, 3}, ps::NamedTuple) where {M, T}
+@inline function (d::ResNetLayer{M, M, false})(x::AbstractArray{T, 3}, ps::NamedTuple) where {M, T}
     return x + d.activation.(mat_tensor_mul(ps.weight, x))
 end
 
-@inline function (d::ResNet{M, M, true})(x::AbstractArray{T, 3}, ps::NamedTuple) where {M, T}
+@inline function (d::ResNetLayer{M, M, true})(x::AbstractArray{T, 3}, ps::NamedTuple) where {M, T}
     return x + d.activation.(mat_tensor_mul(ps.weight, x) .+ ps.bias)
 end
 

--- a/src/layers/transformer.jl
+++ b/src/layers/transformer.jl
@@ -20,7 +20,7 @@ function Transformer(dim::Integer, n_heads::Integer, L::Integer;
     layers = ()
     for _ in 1:L
         layers = (layers..., MultiHeadAttention(dim, n_heads, Stiefel=Stiefel, retraction=retraction, add_connection=add_connection), 
-        ResNet(dim, activation; use_bias=use_bias) )
+        ResNetLayer(dim, activation; use_bias=use_bias) )
     end
 
     Chain(layers...)

--- a/test/arrays/symplectic_potential.jl
+++ b/test/arrays/symplectic_potential.jl
@@ -1,0 +1,40 @@
+using GeometricMachineLearning
+using LinearAlgebra: I
+using Test
+
+function test_setup(n2::Int, T::DataType)
+    @assert iseven(n2) 
+    n = n2 ÷ 2
+
+    one_mat = Matrix{T}(I(n))
+    @test SymplecticPotential(n2, T) ≈ hcat(vcat(zero(one_mat), -one_mat), vcat(one_mat, zero(one_mat)))
+end
+
+function test_application(n2::Int, T::DataType)
+    @assert iseven(n2) 
+
+    𝕁 = SymplecticPotential(n2, T)
+    x = rand(T, n2)
+    y = rand(T, n2)
+
+    @test 𝕁(x, y) ≈ x' * (𝕁 * y) ≈ -𝕁(y, x)
+end
+
+function test_application_nt(n2::Int, T::DataType)
+    @assert iseven(n2) 
+
+    𝕁 = SymplecticPotential(n2, T)
+    n = n2 ÷ 2
+    x = (q = rand(T, n), p = rand(T, n))
+    y = (q = rand(T, n), p = rand(T, n))
+
+    @test 𝕁(x, y) ≈ x.q' * y.p - x.p' * y.q ≈ -𝕁(y, x)
+end
+
+for n2 in 2:2:10
+    for T in (Float32, Float64)
+        test_setup(n2, T)
+        test_application(n2, T)
+        test_application_nt(n2, T)
+    end
+end

--- a/test/layers/resnet_tests.jl
+++ b/test/layers/resnet_tests.jl
@@ -4,8 +4,8 @@ import Random
 Random.seed!(1234)
 
 function test_resnet(M, batch_size=10, T=Float32)
-    model₁ = ResNet(M, tanh, use_bias=false)
-    model₂ = ResNet(M, tanh, use_bias=true)
+    model₁ = ResNetLayer(M, tanh, use_bias=false)
+    model₂ = ResNetLayer(M, tanh, use_bias=true)
     ps₁ = initialparameters(model₁, CPU(), T)
     ps₂ = initialparameters(model₂, CPU(), T) 
     @test parameterlength(model₁) == M^2

--- a/test/network_losses/losses_and_optimization.jl
+++ b/test/network_losses/losses_and_optimization.jl
@@ -1,5 +1,5 @@
 using GeometricMachineLearning
-using GeometricMachineLearning: FeedForwardLoss
+using GeometricMachineLearning: FeedForwardLoss, ResNetLayer
 using Test 
 import Random 
 
@@ -9,7 +9,7 @@ const sin_vector = sin.(0:0.01:2π)
 const dl = DataLoader(reshape(sin_vector, 1, length(sin_vector), 1))
 
 function setup_network(dl::DataLoader{T}) where T
-    arch = Chain(Dense(1, 5, tanh), ResNet(5, tanh), Dense(5, 1, identity))
+    arch = Chain(Dense(1, 5, tanh), ResNetLayer(5, tanh), Dense(5, 1, identity))
     NeuralNetwork(arch, CPU(), T)
 end
 

--- a/test/optimizers/optimizer_convergence_tests/adam_with_learning_rate_decay.jl
+++ b/test/optimizers/optimizer_convergence_tests/adam_with_learning_rate_decay.jl
@@ -9,7 +9,7 @@ const sin_vector = sin.(0:0.1:2π)
 const dl = DataLoader(reshape(sin_vector, 1, length(sin_vector), 1))
 
 function setup_network(dl::DataLoader{T}) where T
-    arch = Chain(Dense(1, 20, tanh), ResNet(20, tanh), Dense(20, 1, identity))
+    arch = Chain(Dense(1, 20, tanh), ResNetLayer(20, tanh), Dense(20, 1, identity))
     NeuralNetwork(arch, CPU(), T)
 end
 

--- a/test/regular_transformer_integrator.jl
+++ b/test/regular_transformer_integrator.jl
@@ -1,0 +1,22 @@
+using GeometricMachineLearning
+using Test
+import Random 
+
+Random.seed!(123)
+
+const sys_dim = 5
+const model = RegularTransformerIntegrator(sys_dim)
+const seq_length = 5
+
+function set_up_and_apply_integrator(; T=Float32)
+    ics = rand(T, sys_dim, seq_length)
+
+    nn = NeuralNetwork(model, CPU(), T)
+
+    iterates = iterate(nn, ics)
+
+    @test ics ≉ iterates[:, (end - seq_length + 1):end]
+end
+
+set_up_and_apply_integrator(; T = Float32)
+set_up_and_apply_integrator(; T = Float64)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,13 +1,15 @@
-
 using SafeTestsets
 
 @safetestset "Check parameterlength                                                           " begin include("parameterlength/check_parameterlengths.jl") end
+
 @safetestset "Arrays #1                                                                       " begin include("arrays/array_tests.jl") end
 @safetestset "Sampling of arrays                                                              " begin include("arrays/random_generation_of_custom_arrays.jl") end
 @safetestset "Addition tests for custom arrays                                                " begin include("arrays/addition_tests_for_custom_arrays.jl") end
 @safetestset "Scalar multiplication tests for custom arrays                                   " begin include("arrays/scalar_multiplication_for_custom_arrays.jl") end
 @safetestset "Matrix multiplication tests for custom arrays                                   " begin include("arrays/matrix_multiplication_for_custom_arrays.jl") end
 @safetestset "Test constructors for custom arrays                                             " begin include("arrays/constructor_tests_for_custom_arrays.jl") end
+@safetestset "Symplectic Potential (array tests)                                              " begin include("arrays/symplectic_potential.jl") end
+
 @safetestset "Manifolds (Grassmann):                                                          " begin include("manifolds/grassmann_manifold.jl") end
 @safetestset "Gradient Layer                                                                  " begin include("layers/gradient_layer_tests.jl") end
 @safetestset "Test symplecticity of upscaling layer                                           " begin include("layers/sympnet_layers_test.jl") end 
@@ -55,3 +57,6 @@ using SafeTestsets
 @safetestset "Test triangular arrays                                                          " begin include("arrays/triangular.jl") end
 
 @safetestset "Test volume-preserving feedforward neural network                               " begin include("layers/volume_preserving_feedforward.jl") end
+
+@safetestset "SympNet integrator                                                              " begin include("sympnet_integrator.jl") end
+@safetestset "Regular transformer integrator                                                  " begin include("regular_transformer_integrator.jl") end

--- a/test/sympnet_integrator.jl
+++ b/test/sympnet_integrator.jl
@@ -1,0 +1,31 @@
+using GeometricMachineLearning
+using Test
+import Random 
+
+Random.seed!(123)
+
+const sys_dim = 2
+const model = GSympNet(sys_dim)
+
+function set_up_and_apply_integrator(; T=Float32)
+    ics₁ = (q = rand(T, sys_dim ÷ 2), p = rand(T, sys_dim ÷ 2))
+    ics₂ = (q = rand(T, sys_dim ÷ 2), p = rand(T, sys_dim ÷ 2))
+    𝕁 = SymplecticPotential(sys_dim, T)
+
+    product₀ = 𝕁(ics₁, ics₂)
+
+    nn = NeuralNetwork(model, CPU(), T)
+
+    iterates₁ = iterate(nn, ics₁)
+    iterates₂ = iterate(nn, ics₂)
+
+    final_iterate₁ = (q = iterates₁.q[:, end], p = iterates₁.p[:, end])
+    final_iterate₂ = (q = iterates₂.q[:, end], p = iterates₂.p[:, end])
+
+    product_final = 𝕁(final_iterate₁, final_iterate₂)
+
+    @test product_final ≉ 0 ≉ product₀ 
+end
+
+set_up_and_apply_integrator(; T = Float32)
+set_up_and_apply_integrator(; T = Float64)

--- a/test/transformer_related/transformer_application.jl
+++ b/test/transformer_related/transformer_application.jl
@@ -1,4 +1,5 @@
 using Test, KernelAbstractions, GeometricMachineLearning
+using GeometricMachineLearning: ResNetLayer
 import Random 
 
 Random.seed!(1234)
@@ -7,8 +8,8 @@ Random.seed!(1234)
 This tests if the size of the input array is kept constant when fed into the transformer (for a matrix and a tensor)
 """
 function transformer_application_test(T, dim, n_heads, L, seq_length=8, batch_size=10)
-    model₁ = Chain(Transformer(dim, n_heads, L, Stiefel=false), ResNet(dim))
-    model₂ = Chain(Transformer(dim, n_heads, L, Stiefel=true), ResNet(dim))
+    model₁ = Chain(Transformer(dim, n_heads, L, Stiefel=false), ResNetLayer(dim))
+    model₂ = Chain(Transformer(dim, n_heads, L, Stiefel=true), ResNetLayer(dim))
 
     ps₁ = initialparameters(model₁, KernelAbstractions.CPU(), T)
     ps₂ = initialparameters(model₂, KernelAbstractions.CPU(), T)

--- a/test/transformer_related/transformer_gradient.jl
+++ b/test/transformer_related/transformer_gradient.jl
@@ -1,4 +1,5 @@
 using Test, KernelAbstractions, GeometricMachineLearning, Zygote, LinearAlgebra
+using GeometricMachineLearning: ResNetLayer
 import Random 
 
 Random.seed!(1234)
@@ -7,8 +8,8 @@ Random.seed!(1234)
 This checks if the gradients of the transformer change the type in case of the Stiefel manifold, and checks if they stay the same in the case of regular weights.
 """
 function transformer_gradient_test(T, dim, n_heads, L, seq_length=8, batch_size=10)
-    model₁ = Chain(Transformer(dim, n_heads, L, Stiefel=false), ResNet(dim))
-    model₂ = Chain(Transformer(dim, n_heads, L, Stiefel=true), ResNet(dim))
+    model₁ = Chain(Transformer(dim, n_heads, L, Stiefel=false), ResNetLayer(dim))
+    model₂ = Chain(Transformer(dim, n_heads, L, Stiefel=true), ResNetLayer(dim))
 
     ps₁ = initialparameters(model₁, KernelAbstractions.CPU(), T)
     ps₂ = initialparameters(model₂, KernelAbstractions.CPU(), T)

--- a/test/transformer_related/transformer_optimizer.jl
+++ b/test/transformer_related/transformer_optimizer.jl
@@ -1,4 +1,5 @@
 using Test, KernelAbstractions, GeometricMachineLearning, Zygote, LinearAlgebra
+using GeometricMachineLearning: ResNetLayer
 import Random 
 
 Random.seed!(1234)
@@ -7,7 +8,7 @@ Random.seed!(1234)
 This function tests if the `GradientOptimzier`, `MomentumOptimizer`, `AdamOptimizer` and `BFGSOptimizer` act on the neural network weights via `optimization_step!`.
 """
 function transformer_gradient_test(T, dim, n_heads, L, seq_length=8, batch_size=10)
-    model = Chain(Transformer(dim, n_heads, L, Stiefel=true), ResNet(dim))
+    model = Chain(Transformer(dim, n_heads, L, Stiefel=true), ResNetLayer(dim))
     model = Transformer(dim, n_heads, L, Stiefel=true)
 
     ps = initialparameters(model, KernelAbstractions.CPU(), T)


### PR DESCRIPTION
Introduced a new type `TransformerIntegrator` that makes the transformer behave similarly to a classical multi-step method. For now this is done by extending `iterate`, but will have to be interfaced with `GeometricIntegratorsBase` eventually. 