### PR TITLE
Removed if statement.

### DIFF
--- a/src/arrays/stiefel_lie_algebra_horizontal.jl
+++ b/src/arrays/stiefel_lie_algebra_horizontal.jl
@@ -156,9 +156,8 @@ end
 
 function Base.zeros(backend::KernelAbstractions.Backend, ::Type{StiefelLieAlgHorMatrix{T}}, N::Integer, n::Integer) where T 
 	StiefelLieAlgHorMatrix(
-			       zeros(backend, SkewSymMatrix{T}, n),
-			       N == n ? KernelAbstractions.allocate(backend, T, N-n, n) : 
-                            KernelAbstractions.zeros(backend, T, N-n, n), N, n)
+			        zeros(backend, SkewSymMatrix{T}, n),
+                    KernelAbstractions.zeros(backend, T, N-n, n), N, n)
 end
 
 


### PR DESCRIPTION
Fixes https://github.com/JuliaGNI/GeometricMachineLearning.jl/issues/166.

There was an `if` statement due to a `KernelAbstractions` bug that was fixed in https://github.com/JuliaGPU/KernelAbstractions.jl/pull/515.