### PR TITLE
Implemented `AbstractPullback`

### DIFF
--- a/docs/src/pullbacks/computation_of_pullbacks.md
+++ b/docs/src/pullbacks/computation_of_pullbacks.md
@@ -101,6 +101,13 @@ T^*_a\mathcal{V} \to T_a\mathcal{V}
 
 is equivalent to applying the [Riemannian gradient](@ref "The Riemannian Gradient").
 
+## Library Functions 
+
+```@docs
+AbstractPullback
+GeometricMachineLearning.ZygotePullback
+```
+
 ```@raw latex
 \begin{comment}
 ```

--- a/src/GeometricMachineLearning.jl
+++ b/src/GeometricMachineLearning.jl
@@ -287,6 +287,9 @@ module GeometricMachineLearning
 
     include("loss/losses.jl")
 
+    export AbstractPullback
+    include("pullback.jl")
+
     export DataLoader, onehotbatch
     export Batch, optimize_for_one_epoch!
     include("data_loader/tensor_assign.jl")

--- a/src/data_loader/optimize.jl
+++ b/src/data_loader/optimize.jl
@@ -72,11 +72,15 @@ function optimize_for_one_epoch!(   opt::Optimizer,
         input_nt_output_nt = convert_input_and_batch_indices_to_array(dl, batch, batch_indices) |> _copy
         loss_value, pullback = _pullback(ps, model, input_nt_output_nt)
         total_error += loss_value
-        dp = return_correct_named_tuple(pullback(one(loss_value))[1])
+        dp = return_correct_named_tuple(_unpack_tuple(pullback(one(loss_value))))
         optimization_step!(opt, λY, ps, dp)
     end
     total_error / count
 end
+
+# this function is necessary because of the way Zygote returns derivatives
+_unpack_tuple(a) = a 
+_unpack_tuple(a::Tuple{<:Any}) = a[1]
 
 # this is needed because of the specific way in which we store nn parameters
 return_correct_named_tuple(dx::NamedTuple{(:params, )}) = dx.params

--- a/src/data_loader/optimize.jl
+++ b/src/data_loader/optimize.jl
@@ -47,7 +47,22 @@ number_of_batches(dl, batch)
 3
 ```
 """
-function optimize_for_one_epoch!(opt::Optimizer, model, ps::Union{NeuralNetworkParameters, NamedTuple}, dl::DataLoader{T}, batch::Batch, loss::Union{typeof(loss), NetworkLoss}, λY) where T
+function optimize_for_one_epoch!(   opt::Optimizer, 
+                                    model, ps::Union{NeuralNetworkParameters, NamedTuple}, 
+                                    dl::DataLoader{T}, 
+                                    batch::Batch, 
+                                    loss::NetworkLoss, 
+                                    λY) where T
+    optimize_for_one_epoch!(opt, model, ps, dl, batch, ZygotePullback(loss), λY)
+end
+
+function optimize_for_one_epoch!(   opt::Optimizer, 
+                                    model, 
+                                    ps::Union{NeuralNetworkParameters, NamedTuple}, 
+                                    dl::DataLoader{T}, 
+                                    batch::Batch, 
+                                    _pullback::AbstractPullback, 
+                                    λY) where T
     count = 0
     total_error = T(0)
     batches = batch(dl)
@@ -55,16 +70,13 @@ function optimize_for_one_epoch!(opt::Optimizer, model, ps::Union{NeuralNetworkP
         count += 1
         # these `copy`s should not be necessary! coming from a Zygote problem!
         input_nt_output_nt = convert_input_and_batch_indices_to_array(dl, batch, batch_indices) |> _copy
-        loss_value, pullback = _pullback(ps, model, input_nt_output_nt, loss)
+        loss_value, pullback = _pullback(ps, model, input_nt_output_nt)
         total_error += loss_value
         dp = return_correct_named_tuple(pullback(one(loss_value))[1])
         optimization_step!(opt, λY, ps, dp)
     end
     total_error / count
 end
-
-_pullback(ps, model, input_nt_output_nt, loss) = Zygote.pullback(ps -> loss(model, ps, input_nt_output_nt), ps)
-_pullback(ps, model, input_nt_output_nt::Tuple, loss) = Zygote.pullback(ps -> loss(model, ps, input_nt_output_nt...), ps)
 
 # this is needed because of the specific way in which we store nn parameters
 return_correct_named_tuple(dx::NamedTuple{(:params, )}) = dx.params
@@ -74,12 +86,17 @@ _copy(a::AbstractArray) = copy(a)
 _copy(qp::QPT) = (q = copy(qp.q), p = copy(qp.p))
 _copy(t::Tuple{<:QPTOAT, <:QPTOAT}) = _copy.(t)
 
-function (o::Optimizer)(nn::NeuralNetwork, dl::DataLoader, batch::Batch, n_epochs::Integer, loss::NetworkLoss; show_progress = true)
+function (o::Optimizer)(nn::NeuralNetwork, 
+                        dl::DataLoader, 
+                        batch::Batch, 
+                        n_epochs::Integer, 
+                        loss::NetworkLoss, 
+                        _pullback::AbstractPullback = ZygotePullback(loss); show_progress = true)
     Λ = GlobalSection(nn.params)
     progress_object = show_progress == true ? ProgressMeter.Progress(n_epochs; enabled=true) : nothing
     loss_array = zeros(n_epochs)
     for i in 1:n_epochs
-        loss_array[i] = optimize_for_one_epoch!(o, nn.model, nn.params, dl, batch, loss, Λ)
+        loss_array[i] = optimize_for_one_epoch!(o, nn.model, nn.params, dl, batch, _pullback, Λ)
         show_progress == true ? ProgressMeter.next!(progress_object; showvalues = [(:TrainingLoss, loss_array[i])]) : nothing
     end
 

--- a/src/pullback.jl
+++ b/src/pullback.jl
@@ -1,0 +1,28 @@
+"""
+    AbstractPullback{NNLT<:NetworkLoss}
+
+`AbstractPullback` is an `abstract type` that encompasses all ways of performing differentiation (especially computing the gradient with respect to neural network parameters) in `GeometricMachineLearning`.
+
+If a user wants to implement a custom `Pullback` the following two functions have to be extended:
+```julia
+(_pullback::AbstractPullback)(ps, model, input_nt_output_nt::Tuple{<:QPTOAT, <:QPTOAT})
+(_pullback::AbstractPullback)(ps, model, input_nt::QPT)
+```
+based on the `loss::NetworkLoss` that's stored in `_pullback`. Also see [`ZygotePullback`](@ref).
+"""
+abstract type AbstractPullback{NNLT<:NetworkLoss} end
+
+(_pullback::AbstractPullback)(ps, model, input_nt_output_nt::Tuple{<:QPTOAT, <:QPTOAT}) = error("Pullback not implemented for input-output pair!")
+(_pullback::AbstractPullback)(ps, model, input_nt::QPT) = error("Pullback not implemented for single input!")
+
+"""
+    ZygotePullback <: AbstractPullback
+
+The pullback based on the [`Zygote`](https://github.com/FluxML/Zygote.jl) backend.
+"""
+struct ZygotePullback{NNLT} <: AbstractPullback{NNLT}
+    loss::NNLT
+end
+
+(_pullback::ZygotePullback)(ps, model, input_nt::QPTOAT) = Zygote.pullback(ps -> _pullback.loss(model, ps, input_nt), ps)
+(_pullback::ZygotePullback)(ps, model, input_nt_output_nt::Tuple{<:QPTOAT, <:QPTOAT}) = Zygote.pullback(ps -> _pullback.loss(model, ps, input_nt_output_nt...), ps)

--- a/src/pullback.jl
+++ b/src/pullback.jl
@@ -1,4 +1,4 @@
-"""
+@doc raw"""
     AbstractPullback{NNLT<:NetworkLoss}
 
 `AbstractPullback` is an `abstract type` that encompasses all ways of performing differentiation (especially computing the gradient with respect to neural network parameters) in `GeometricMachineLearning`.


### PR DESCRIPTION
`ZygotePullback` is implemented in `GeometricMachineLearning` (same commit: https://github.com/JuliaGNI/GeometricMachineLearning.jl/pull/173/commits/e638e4256980922efaf676ed00e8021a1344a0ea), `SymbolicPullback` will be implemented in [`SymbolicNeuralNetworks`](https://github.com/JuliaGNI/SymbolicNeuralNetworks.jl).