### PR TITLE
Adusted GML to import `FeedForwardLoss` from `AbstractNeuralNetworks`.

### DIFF
--- a/docs/src/architectures/sympnet.md
+++ b/docs/src/architectures/sympnet.md
@@ -189,7 +189,7 @@ The universal approximation theorems state that we can, in principle, get arbitr
 
 To train the SympNet, one needs data along a trajectory such that the model is trained to perform an integration. The loss function is defined as[^6]:
 
-[^6]: This loss function is implemented as [`FeedForwardLoss`](@ref) in `GeometricMachineLearning`.
+[^6]: This loss function is implemented as `FeedForwardLoss` in `AbstractNeuralNetworks`.
 
 ```math
 \mathrm{loss}(z^\mathrm{c}, z^\mathrm{p}) = \frac{|| z^\mathrm{c} - z^\mathrm{p} ||}{|| z^\mathrm{c} ||},

--- a/docs/src/reduced_order_modeling/losses.md
+++ b/docs/src/reduced_order_modeling/losses.md
@@ -4,7 +4,7 @@ In general we distinguish between *losses* that are used during training of a ne
 
 ## Different Neural Network Losses
 
-`GeometricMachineLearning` has a number of loss functions implemented that can be called *standard losses*. Those are the [`FeedForwardLoss`](@ref), the [`TransformerLoss`](@ref), the [`AutoEncoderLoss`](@ref) and the [`ReducedLoss`](@ref). How to implement custom losses is shown in a [tutorial](@ref "Adjusting the Loss Function").
+`GeometricMachineLearning` has a number of loss functions implemented that can be called *standard losses*. Those are the `FeedForwardLoss` (defined in `AbstractNeuralNetworks`), the [`TransformerLoss`](@ref), the [`AutoEncoderLoss`](@ref) and the [`ReducedLoss`](@ref). How to implement custom losses is shown in a [tutorial](@ref "Adjusting the Loss Function").
 
 ## A Note on Physics-Informed Neural Networks
 
@@ -43,7 +43,6 @@ where ``\mathbf{x}^{(t)}`` is the solution of the FOM at point ``t`` and ``\math
 ## Library Functions
 
 ```@docs
-FeedForwardLoss
 TransformerLoss
 AutoEncoderLoss
 ReducedLoss

--- a/docs/src/tutorials/sympnet_tutorial.md
+++ b/docs/src/tutorials/sympnet_tutorial.md
@@ -9,7 +9,7 @@ This page serves as a short introduction into using [SympNets](@ref "SympNet Arc
 
 ## Loss function
 
-The [`FeedForwardLoss`](@ref) is the default choice used in `GeometricMachineLearning` for training SympNets, this can however be changed or [tweaked](@ref "Adjusting the Loss Function").
+The `FeedForwardLoss` is the default choice used in `GeometricMachineLearning` for training SympNets, this can however be changed or [tweaked](@ref "Adjusting the Loss Function").
 
 ## Training a Harmonic Oscillator
 

--- a/docs/src/tutorials/volume_preserving_attention.md
+++ b/docs/src/tutorials/volume_preserving_attention.md
@@ -6,7 +6,7 @@ In here we demonstrate the differences between the two approaches for computing 
 
 ```@example volume_preserving_attention
 using GeometricMachineLearning # hide
-using GeometricMachineLearning: FeedForwardLoss, TransformerLoss, params # hide
+using GeometricMachineLearning: TransformerLoss, params # hide
 import Random # hide
 Random.seed!(123) # hide
 sine_cosine = zeros(1, 1000, 2)

--- a/src/GeometricMachineLearning.jl
+++ b/src/GeometricMachineLearning.jl
@@ -22,7 +22,7 @@ module GeometricMachineLearning
     using SymbolicNeuralNetworks: derivative, _get_contents, _get_params, SymbolicNeuralNetwork
     using Symbolics: @variables, substitute
 
-    import AbstractNeuralNetworks: Architecture, Model, AbstractExplicitLayer, AbstractExplicitCell, AbstractNeuralNetwork , NeuralNetwork, UnknownArchitecture
+    import AbstractNeuralNetworks: Architecture, Model, AbstractExplicitLayer, AbstractExplicitCell, AbstractNeuralNetwork , NeuralNetwork, UnknownArchitecture, FeedForwardLoss
     import AbstractNeuralNetworks: Chain, GridCell
     import AbstractNeuralNetworks: Dense, Linear, Recurrent
     import AbstractNeuralNetworks: IdentityActivation, ZeroVector

--- a/src/loss/losses.jl
+++ b/src/loss/losses.jl
@@ -102,51 +102,6 @@ function (loss::ClassificationTransformerLoss)(model::Union{Chain, AbstractExpli
 end
 
 @doc raw"""
-    FeedForwardLoss()
-
-Make an instance of a loss for feedforward neural networks.
-
-This should be used together with a neural network of type [`NeuralNetworkIntegrator`](@ref).
-
-# Example 
-
-`FeedForwardLoss` applies a neural network to an input and compares it to the `output` via an ``L_2`` norm:
-
-```jldoctest 
-using GeometricMachineLearning
-using LinearAlgebra: norm
-import Random
-Random.seed!(123)
-
-const d = 2
-arch = GSympNet(d)
-nn = NeuralNetwork(arch)
-
-input_vec =  [1., 2.]
-output_vec = [3., 4.]
-loss = FeedForwardLoss()
-
-loss(nn, input_vec, output_vec) ≈ norm(output_vec - nn(input_vec)) / norm(output_vec)
-
-# output
-
-true
-```
-
-So `FeedForwardLoss` simply does:
-
-```math
-    \mathtt{loss}(\mathcal{NN}, \mathtt{input}, \mathtt{output}) = || \mathcal{NN}(\mathtt{input}) - \mathtt{output} || / || \mathtt{output}||,
-```
-where ``||\cdot||`` is the ``L_2`` norm. 
-
-# Parameters
-
-This loss does not have any parameters.
-"""
-struct FeedForwardLoss <: NetworkLoss end
-
-@doc raw"""
     AutoEncoderLoss()
 
 Make an instance of `AutoEncoderLoss`.
@@ -191,13 +146,15 @@ This loss does not have any parameters.
 """
 struct AutoEncoderLoss <: NetworkLoss end 
 
-function (loss::AutoEncoderLoss)(nn::NeuralNetwork, input)
+function (loss::AutoEncoderLoss)(nn::NeuralNetwork, input::QPTOAT)
     loss(nn.model, params(nn), input, input)
 end
 
-function (loss::AutoEncoderLoss)(model::Union{Chain, AbstractExplicitLayer}, ps::Union{NeuralNetworkParameters, NamedTuple}, input)
+function (loss::AutoEncoderLoss)(model::Union{Chain, AbstractExplicitLayer}, ps::Union{NeuralNetworkParameters, NamedTuple}, input::QPTOAT)
     loss(model, ps, input, input)
 end
+
+(loss::AutoEncoderLoss)(model::Union{Chain, AbstractExplicitLayer}, ps::Union{NeuralNetworkParameters, NamedTuple}, input::QPTOAT, output::QPTOAT) = FeedForwardLoss()(model, ps, input, output)
 
 @doc raw"""
     ReducedLoss(encoder, decoder)

--- a/src/optimizers/optimizer.jl
+++ b/src/optimizers/optimizer.jl
@@ -24,7 +24,7 @@ The arguments are:
 
 The last argument is optional for many neural network architectures. We have the following defaults:
 - A [`TransformerIntegrator`](@ref) uses [`TransformerLoss`](@ref).
-- A [`NeuralNetworkIntegrator`](@ref) uses [`FeedForwardLoss`](@ref).
+- A [`NeuralNetworkIntegrator`](@ref) uses `FeedForwardLoss` (this loss is defined in `AbstractNeuralNetworks`).
 - An [`AutoEncoder`](@ref) uses [`AutoEncoderLoss`](@ref).
 
 In addition there is an optional keyword argument that can be supplied to the functor:

--- a/test/network_losses/losses_and_optimization.jl
+++ b/test/network_losses/losses_and_optimization.jl
@@ -1,5 +1,5 @@
 using GeometricMachineLearning
-using GeometricMachineLearning: FeedForwardLoss, ResNetLayer
+using GeometricMachineLearning: ResNetLayer
 using Test 
 import Random 
 

--- a/test/optimizers/optimizer_convergence_tests/adam_with_learning_rate_decay.jl
+++ b/test/optimizers/optimizer_convergence_tests/adam_with_learning_rate_decay.jl
@@ -23,7 +23,7 @@ function train_network(; n_epochs=2048)
     o₂ = Optimizer(AdamOptimizerWithDecay(n_epochs), nn₂)
 
     batch = Batch(5, 1)
-    loss = GeometricMachineLearning.FeedForwardLoss()
+    loss = FeedForwardLoss()
 
     loss_array₁ = o₁(nn₁, dl, batch, n_epochs, loss)
     loss_array₂ = o₂(nn₂, dl, batch, n_epochs, loss)


### PR DESCRIPTION
Without this pr `FeedForwardLoss` would be defined twice (in `AbstractNeuralNetworks` and in `GeometricMachineLearning`).  
Also see https://github.com/JuliaGNI/AbstractNeuralNetworks.jl/commit/9d24c971a02087291c993603d93863f5b8eaecb4 and https://github.com/JuliaGNI/SymbolicNeuralNetworks.jl/pull/32/commits/1db4ee9f7d884cadb0f35d88c791c6267b7391f7. The latter links to a related commit in `SymbolicNeuralNetworks`.