### PR TITLE
Let SymplecticEuler say how it meets the layerwise seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,63 @@ breaking release).
 
 ## [Unreleased]
 
+### Added
+
+- **`SymplecticEuler` declares how it meets the layerwise pullback's seam**, which is what
+  [#245](https://github.com/JuliaGNI/GeometricMachineLearning.jl/issues/245) was waiting for.
+
+  `SymbolicNeuralNetworks` composes the pullback of a chain layer by layer, putting fresh symbolic
+  variables between two layers instead of inlining one layer's expression into the next. Its seam was a
+  plain vector, so it assumed every layer maps an array to an array; a `SymplecticEuler` built with
+  `return_parameters = true` threads the parameters of the system on to the next layer and returns a
+  `Tuple`, which could not be seeded at all
+  ([SNN #54](https://github.com/JuliaGNI/SymbolicNeuralNetworks.jl/issues/54)).
+  SymbolicNeuralNetworks 0.7 widened the seam; `SymplecticEuler` now carries `SymbolicEnergy`'s
+  `parameter_length` and `parameter_layout` and implements `carried_variables`, `seam_value`,
+  `state_expressions` and `seam_arguments`.
+
+  So
+
+  ```julia
+  SymbolicNeuralNetworks.SymbolicPullback(SymbolicNeuralNetwork(arch), FeedForwardLoss())
+  ```
+
+  builds for any `n_integrators` — four steps for two integrators in about 1.5 s, against a monolithic
+  expression of 10⁹ terms that never finished — and agrees with `Zygote` to machine precision.
+
+  For an architecture built with `parameters` it is the *only* construction that builds at all. The
+  monolithic one traces the chain from a plain vector, so every layer defaults its system parameters to
+  `NullParameters` and the energy network's first `Dense` is then short of the components it reads; the
+  build fails inside `Symbolics`. The layerwise construction is given the pair
+  `(state, system parameters)` and differentiates the map that was actually asked for.
+
+- **`ParametricLoss` declares its `loss_expression`.** The layerwise construction starts its sweep from
+  ∂L/∂ŷ and cannot guess one here — it applies a loss in its four-argument form, and this loss has five
+  — so it would have declined and fallen back to the monolithic construction, which for a
+  parameter-dependent architecture does not build. The declaration restates `_compute_loss`, which is
+  what the functor itself uses.
+
+### Changed
+
+- **`_check_symbolic_pullback_is_tractable` says where to go instead**, and now guards
+  `SymbolicPullback(arch)` as well as `SymbolicPullback(nn, ::ParametricLoss, system_params)`. Both
+  still build one expression for the whole network, so the `n_integrators > 1` limit is still real for
+  them — the first because `HNNLoss` evaluates the pre-built Hamiltonian vector field rather than the
+  chain, so there is no prediction for a layerwise seed to start from. `SymbolicPullback(arch)`
+  previously had no guard and failed with an obscure `Symbolics` error instead.
+
+  Migrating `SymbolicPullback(nn, ::ParametricLoss, system_params)` onto the upstream constructor —
+  which would also retire its concatenation of the system parameters onto the network input — is
+  [#245](https://github.com/JuliaGNI/GeometricMachineLearning.jl/issues/245)'s remaining half.
+
+### Known limitation
+
+- The layerwise sweep runs the forward pass by *calling* each layer, so it inherits `SymplecticEuler`'s
+  own single-sample restriction (`@view(…)[:, 1]`, and `@assert size(qp, 2) == 1` in
+  `concatenate_array_with_parameters`). A batch of more than one sample has to be taken sample by
+  sample, as `apply_parametric` already does. The monolithic construction does not have this
+  restriction, because it never calls the layer at run time.
+
 ### Removed (breaking)
 
 - **`RecurrentNeuralNetwork` and `LSTMNeuralNetwork`**, along with

--- a/src/architectures/generalized_hamiltonian_neural_network.jl
+++ b/src/architectures/generalized_hamiltonian_neural_network.jl
@@ -125,9 +125,15 @@ function build_gradient(se::SymbolicEnergy)
                                              inplace = false)
 end
 
-struct SymplecticEuler{M, N, FT<:Base.Callable, MT<:Chain, type, ReturnParameters} <: AbstractExplicitLayer{M, N}
+# `parameter_length` and `parameter_layout` are `SymbolicEnergy`'s, carried here because the layer is
+# what the layerwise `SymbolicPullback` asks about its seam -- see `carried_variables` below. `PT` is
+# the *last* type parameter so that every existing partial signature (`SymplecticEulerA{M, N, FT, AT,
+# false}` and the like) goes on matching, with the layout left free.
+struct SymplecticEuler{M, N, FT<:Base.Callable, MT<:Chain, type, ReturnParameters, PT} <: AbstractExplicitLayer{M, N}
     gradient_function::FT
     energy_model::MT
+    parameter_length::Int
+    parameter_layout::PT
 end
 
 function parameterlength(integrator::SymplecticEuler)
@@ -147,7 +153,9 @@ Changes ``q`` (based on the kinetic energy).
 function SymplecticEulerA(se::SymbolicKineticEnergy; return_parameters::Bool)
     gradient_function = build_gradient(se)
     c = Chain(se)
-    SymplecticEuler{se.dim, se.dim, typeof(gradient_function), typeof(c), :A, return_parameters}(gradient_function, c)
+    SymplecticEuler{se.dim, se.dim, typeof(gradient_function), typeof(c), :A, return_parameters,
+                    typeof(se.parameter_layout)}(gradient_function, c, se.parameter_length,
+                                                 se.parameter_layout)
 end
 
 """
@@ -156,7 +164,9 @@ Changes ``p`` (based on the potential energy).
 function SymplecticEulerB(se::SymbolicPotentialEnergy; return_parameters::Bool)
     gradient_function = build_gradient(se)
     c = Chain(se)
-    SymplecticEuler{se.dim, se.dim, typeof(gradient_function), typeof(c), :B, return_parameters}(gradient_function, c)
+    SymplecticEuler{se.dim, se.dim, typeof(gradient_function), typeof(c), :B, return_parameters,
+                    typeof(se.parameter_layout)}(gradient_function, c, se.parameter_length,
+                                                 se.parameter_layout)
 end
 
 # A network with no system parameters gets its input unchanged; without this the empty flat vector
@@ -234,6 +244,79 @@ function (integrator::SymplecticEuler{M, N, FT, AT, Type, false})(qp::AbstractAr
 end
 
 (integrator::SymplecticEuler)(qp::QPTOAT2, params::NetworkParameters) = integrator(qp, NullParameters(), params)
+
+# ---------------------------------------------------------------------------------------------------
+# The seam of the layerwise `SymbolicPullback`
+#
+# `SymbolicNeuralNetworks` composes the pullback of a chain layer by layer, putting *fresh* symbolic
+# variables between two layers instead of inlining one layer's expression into the next -- which is
+# what keeps the symbolic material a sum over layers rather than a product. By default that seam is a
+# single vector, the state, so it assumes every layer maps an array to an array.
+#
+# A `SymplecticEuler` built with `return_parameters = true` does not: it threads the parameters of the
+# *system* on to the next layer, so it takes and returns a pair. The four methods below say how it
+# meets the seam; see `SymbolicNeuralNetworks.seam_interface`.
+#
+# Without them the construction declines and the monolithic one takes over, which does not get there:
+# for `n_integrators > 1` its expression exceeds 10⁹ terms and never finishes, and for a system that
+# *has* parameters it cannot be built at all. That last one is worth spelling out -- it traces the chain
+# from a plain vector, so the two-argument functor above defaults the system parameters away, and the
+# energy network's first `Dense` is then short of the components it reads. The build fails inside
+# `Symbolics` rather than quietly returning the parameter-free gradient, but only because the
+# dimensions happen not to line up; the layerwise construction is the one that differentiates the map
+# that was asked for.
+
+# A system with no parameters carries nothing, and says so with an empty tuple rather than an empty
+# array: there is nothing to hand the generated kernels, and the seam is then the plain vector it is
+# for every other layer. The layer still has to be *given* a `NullParameters`, which `seam_value`
+# supplies as a constant.
+SymbolicNeuralNetworks.carried_variables(integrator::SymplecticEuler) =
+    iszero(integrator.parameter_length) ? () :
+    (SymbolicNeuralNetworks.Symbolics.variables(:π, 1:integrator.parameter_length),)
+
+# The kernels take the system parameters flat, which is how the forward pass feeds them to the energy
+# network as well (`concatenate_array_with_parameters`). The layer itself wants them in their own
+# shape, so the seam puts them back through the layout it carries.
+SymbolicNeuralNetworks.seam_value(integrator::SymplecticEuler, sqp, sparameters) =
+    (sqp, unflatten(integrator.parameter_layout, sparameters))
+SymbolicNeuralNetworks.seam_value(::SymplecticEuler, sqp) = (sqp, NullParameters())
+
+# `return_parameters = true` returns the state *and* the system parameters; the sensitivity of the
+# loss pairs with the state. With `false` the output is the state alone, which is the default.
+SymbolicNeuralNetworks.state_expressions(::SymplecticEuler{M, N, FT, AT, T, true}, y) where {M, N, FT, AT, T} =
+    SymbolicNeuralNetworks.scalar_expressions(first(y))
+
+# The run-time counterpart of `seam_value`. Every data argument of a generated function has to have the
+# state's rank and batch size, so one parameter set for the whole batch is broadcast out to one column
+# per sample -- what `concatenate_array_with_parameters` does for the forward pass.
+function SymbolicNeuralNetworks.seam_arguments(integrator::SymplecticEuler, qp_params::Tuple)
+    state = _seam_state(first(qp_params))
+    iszero(integrator.parameter_length) ? (state,) :
+        (state, _seam_parameters(last(qp_params), state))
+end
+
+# The state alone is only a seam for a parameter-free system. For any other it would hand the kernel a
+# carried datum of the wrong length, which nothing downstream checks -- the batch dimension is checked,
+# the leading one is not -- so say so here rather than compute the wrong gradient. In practice the
+# forward pass of the sweep, which runs first, usually fails on the same input before this is reached;
+# this is the guard for the case where it does not.
+function SymbolicNeuralNetworks.seam_arguments(integrator::SymplecticEuler, qp::QPTOAT2)
+    iszero(integrator.parameter_length) || throw(ArgumentError(
+        "the system of this `SymplecticEuler` has $(integrator.parameter_length) parameter(s), so " *
+        "the pullback has to be given `(state, system parameters)` rather than the state alone."))
+    (_seam_state(qp),)
+end
+
+# The seam holds the `2n` state components as one array, which is how the layer's own array methods
+# take the state too; a `(q, p)` pair is stacked the way `assign_q_and_p` takes it apart again.
+_seam_state(qp::AbstractArray) = qp
+_seam_state(qp::QPT) = vcat(qp.q, qp.p)
+
+_seam_parameters(parameters::OptionalParameters, ::AbstractVector) =
+    _flatten_system_parameters(parameters)[1]
+_seam_parameters(parameters::OptionalParameters, state::AbstractMatrix) =
+    repeat(_flatten_system_parameters(parameters)[1], 1, size(state, 2))
+
 
 """
     GeneralizedHamiltonianArchitecture <: HamiltonianArchitecture

--- a/src/loss/losses.jl
+++ b/src/loss/losses.jl
@@ -279,3 +279,14 @@ function (loss::ParametricLoss)(model::Chain,
         system_parameters::Union{NamedTuple, AbstractVector}) where {CT <: QPTOAT}
     _compute_loss(apply_parametric(model, input, system_parameters, params), output)
 end
+
+# The layerwise `SymbolicPullback` starts its sweep from ∂L/∂ŷ, so it needs the loss as a function of
+# the prediction and the target. It cannot guess one here: the guess applies the loss in its
+# four-argument form, and this loss has five arguments, so `loss_seed` would decline and the
+# construction fall back to the monolithic one -- which for a parameter-dependent architecture does not
+# build at all, since it traces the chain from a plain vector and the layers then default the system
+# parameters away.
+#
+# `_compute_loss` is the relation the functor above makes, so declaring it is a restatement and not a
+# second definition that could drift.
+SymbolicNeuralNetworks.loss_expression(::ParametricLoss, ŷ, y) = _compute_loss(ŷ, y)

--- a/src/pullbacks/symbolic_hnn_pullback.jl
+++ b/src/pullbacks/symbolic_hnn_pullback.jl
@@ -14,6 +14,7 @@ Hamiltonian *vector field*, which has the dimension of the network's *input*. Th
 below is the upstream one with that one dimension corrected.
 """
 function SymbolicPullback(arch::HamiltonianArchitecture)
+    _check_symbolic_pullback_is_tractable(arch)
     nn = SymbolicNeuralNetwork(arch)
     loss = HNNLoss(arch)
     soutput = Symbolics.variables(:y, 1:input_dimension(nn.model))
@@ -49,28 +50,45 @@ additively. Measured at `dim = 4, width = 4, nhidden = 1`:
 So one integrator is fine — and worth it, the built function evaluates about 100 times faster than
 the `Zygote` pullback — while two are hopeless. Rather than let that look like a hang, refuse it.
 
-Removing the limit means not tracing the inlined chain at all: composing the pullback layer by layer
-from the gradients each `SymplecticEuler` has already built.
+The way out is not to trace the inlined chain at all, but to compose the pullback layer by layer.
+`SymbolicNeuralNetworks` 0.6 added that construction
+([SNN #49](https://github.com/JuliaGNI/SymbolicNeuralNetworks.jl/issues/49)) and 0.7 widened its seam
+so that it reaches a `SymplecticEuler`, which threads the parameters of the system on to the next layer
+and therefore returns a `Tuple` rather than an array
+([SNN #54](https://github.com/JuliaGNI/SymbolicNeuralNetworks.jl/issues/54); the layer says how it
+meets the seam in `src/architectures/generalized_hamiltonian_neural_network.jl`). So
 
-`SymbolicNeuralNetworks` 0.6 added exactly that construction
-([SNN #49](https://github.com/JuliaGNI/SymbolicNeuralNetworks.jl/issues/49)), but it does not reach
-this case yet. Its seam is a plain `Vector{Num}`, so it assumes every layer maps an array to an
-array; a `SymplecticEuler` built with `return_parameters = true` passes the system parameters on to
-the next layer and returns a `Tuple`, which `layer_seed` cannot seed. `composes_layerwise` says the
-chain decomposes, so `layerwise = :auto` commits to that path and then raises — which is
-[SNN #54](https://github.com/JuliaGNI/SymbolicNeuralNetworks.jl/issues/54). Until the seam can carry
-what a layer passes alongside the state, this limit stays. See
-[issue #245](https://github.com/JuliaGNI/GeometricMachineLearning.jl/issues/245).
+```julia
+SymbolicNeuralNetworks.SymbolicPullback(SymbolicNeuralNetwork(arch), FeedForwardLoss())
+```
+
+builds for any `n_integrators` — four steps for two integrators in about 1.5 s, against an expression
+of 10⁹ terms that never finished — and for an architecture built with `parameters` it is the *only*
+construction that builds, since the monolithic one traces the chain from a plain vector and the layers
+then default the system parameters away.
+
+This function guards the two constructors *in this file*, which still build one expression for the
+whole network by hand, and the limit is still real for them:
+
+- `SymbolicPullback(arch)` uses [`HNNLoss`](@ref), which never applies the model — it evaluates the
+  pre-built Hamiltonian vector field and reads the parameters directly. It is therefore not a function
+  of the chain's prediction at all, which is what a layerwise seed has to start from, so the layerwise
+  construction cannot express it.
+- `SymbolicPullback(nn, loss, system_params)` predates the widened seam. [`ParametricLoss`](@ref) now
+  declares its `loss_expression`, so the upstream constructor can seed it; migrating this one onto it
+  would also retire the input concatenation below, and is
+  [issue #245](https://github.com/JuliaGNI/GeometricMachineLearning.jl/issues/245)'s remaining half.
 """
 function _check_symbolic_pullback_is_tractable(arch)
     n = _n_symplectic_integrators(arch)
     n > 1 && throw(ArgumentError(
-        "cannot build a `SymbolicPullback` for an architecture with $(n) integrators: the symbolic " *
-        "expression grows multiplicatively with `n_integrators`, and already exceeds 10⁹ terms at " *
-        "two, so the build does not finish. Use `ZygotePullback(loss)`, which is what `Optimizer` " *
-        "uses by default, or reduce `n_integrators` to 1. See GeometricMachineLearning issue #245, " *
-        "and SymbolicNeuralNetworks issues #49 and #54 for the upstream construction that will " *
-        "eventually lift this."))
+        "cannot build *this* `SymbolicPullback` for an architecture with $(n) integrators: it builds " *
+        "one symbolic expression for the whole network, which grows multiplicatively with " *
+        "`n_integrators` and already exceeds 10⁹ terms at two, so the build does not finish. " *
+        "`SymbolicNeuralNetworks.SymbolicPullback(SymbolicNeuralNetwork(arch), FeedForwardLoss())` " *
+        "composes the pullback layer by layer instead and has no such limit; `ZygotePullback(loss)`, " *
+        "which is what `Optimizer` uses by default, is the other option. See " *
+        "GeometricMachineLearning issue #245 and SymbolicNeuralNetworks issues #49 and #54."))
     nothing
 end
 

--- a/test/generalized_hamiltonian_neural_networks/layerwise_symbolic_pullback_test.jl
+++ b/test/generalized_hamiltonian_neural_networks/layerwise_symbolic_pullback_test.jl
@@ -1,0 +1,144 @@
+# The layerwise `SymbolicPullback` on a parameter-dependent generalized HNN.
+#
+# `SymbolicNeuralNetworks` composes the pullback of a chain layer by layer, putting fresh symbolic
+# variables between two layers instead of inlining one layer's expression into the next. Until
+# SymbolicNeuralNetworks 0.7 that seam was a plain vector, so a `SymplecticEuler` built with
+# `return_parameters = true` -- which threads the parameters of the system on to the next layer, and so
+# returns a `Tuple` -- could not be seeded at all (SNN #54). It now says how it meets the seam, which is
+# what GML #245 was waiting for.
+#
+# Two things are worth testing beyond agreement. First, `n_integrators > 1`: the monolithic expression
+# grows multiplicatively with it and exceeds 10⁹ terms at two, so nothing built that before. Second, an
+# architecture with `parameters`: the monolithic construction traces the chain from a plain vector, so
+# the layers default the system parameters away and it does not build at all -- the layerwise
+# construction is the only one that is right there, not merely the quicker one.
+#
+# `Zygote` is the reference throughout. The losses here are not additive over a batch (both normalise
+# by `norm(output)` taken over the whole of it), and `SymbolicPullback` sums the per-sample gradients,
+# so the comparison is on a single sample -- the same statement SymbolicNeuralNetworks' own suite pins
+# down for `FeedForwardLoss`.
+
+using GeometricMachineLearning
+using GeometricMachineLearning: ParametricLoss, apply_parametric, _unwrap_gradient
+using SymbolicNeuralNetworks
+using SymbolicNeuralNetworks: composes_layerwise, symbolic_steps, layerwise_gradient_function,
+                              loss_seed, checked_layer_seed, layer_seed
+using AbstractNeuralNetworks: FeedForwardLoss, params, layers
+using NeuralNetworkParameters: flatten
+using LinearAlgebra: norm
+using Random: seed!
+using Test
+import Zygote
+
+seed!(1234)
+
+# The gradients nest -- a `SymplecticEuler` holds the parameters of a whole energy sub-network -- so
+# they are compared through their flat form rather than key by key.
+flat(gradient) = flatten(_unwrap_gradient(gradient))[1]
+maximum_difference(a, b) = maximum(abs, flat(a) - flat(b))
+construction(pullback) = typeof(pullback.fun.gradient_function).name.name
+
+input, output = rand(4, 1), rand(4, 1)
+system_parameters = (m = 1.0, ω = π / 2)
+
+@testset "the chain decomposes and every layer can now be seeded: $n integrator(s)" for n in (1, 2)
+    arch = GeneralizedHamiltonianArchitecture(4; width = 4, nhidden = 1, n_integrators = n)
+    snn = SymbolicNeuralNetwork(arch)
+    sparams = params(snn)
+
+    # two steps per integrator: one `SymplecticEulerA`, one `SymplecticEulerB`
+    @test length(symbolic_steps(snn)) == 2n
+    @test composes_layerwise(snn)
+    # all but the last thread the system parameters on, and used to be the ones that could not be seeded
+    for (layer, key) in symbolic_steps(snn)
+        @test !isnothing(checked_layer_seed(layer, key, sparams[key]))
+    end
+    @test !isnothing(layerwise_gradient_function(snn, FeedForwardLoss()))
+end
+
+@testset "a parameter-free GHNN agrees with the monolithic path and with Zygote" begin
+    arch = GeneralizedHamiltonianArchitecture(4; width = 4, nhidden = 1, n_integrators = 1)
+    snn, nn = SymbolicNeuralNetwork(arch), NeuralNetwork(arch, Float64)
+    loss = FeedForwardLoss()
+
+    layerwise = SymbolicNeuralNetworks.SymbolicPullback(snn, loss; layerwise = :auto)
+    monolithic = SymbolicNeuralNetworks.SymbolicPullback(snn, loss; layerwise = false)
+    # `:auto` used to throw here, on a network the monolithic path builds without trouble
+    @test construction(layerwise) == :LayerwiseGradientFunction
+    @test construction(monolithic) != :LayerwiseGradientFunction
+
+    gradient = layerwise.fun(input, output, params(nn))(1)
+    @test maximum_difference(gradient, monolithic.fun(input, output, params(nn))(1)) < 1e-14
+    reference = Zygote.gradient(p -> loss(nn.model, p, input, output), params(nn))[1]
+    @test maximum_difference(gradient, reference) < 1e-14
+end
+
+# The expression of two integrators has about 10⁹ terms, so this is the first construction that reaches
+# it at all.
+@testset "two integrators build, which no monolithic expression does" begin
+    arch = GeneralizedHamiltonianArchitecture(4; width = 4, nhidden = 1, n_integrators = 2)
+    snn, nn = SymbolicNeuralNetwork(arch), NeuralNetwork(arch, Float64)
+    loss = FeedForwardLoss()
+
+    pullback = SymbolicNeuralNetworks.SymbolicPullback(snn, loss; layerwise = true)
+    @test length(pullback.fun.gradient_function.steps) == 4
+    # the sweep never asks the first layer for the sensitivity to its input
+    @test isnothing(first(pullback.fun.gradient_function.steps).dλ)
+
+    reference = Zygote.gradient(p -> loss(nn.model, p, input, output), params(nn))[1]
+    @test maximum_difference(pullback.fun(input, output, params(nn))(1), reference) < 1e-14
+
+    # GML's own two constructors still build one expression for the whole network, so their limit
+    # stands and now says where to go instead. `SymbolicPullback(arch)` uses `HNNLoss`, which
+    # evaluates the pre-built vector field rather than the chain, so there is no prediction for a
+    # layerwise seed to start from at all.
+    raised = try
+        SymbolicPullback(arch)
+    catch error
+        error
+    end
+    @test raised isa ArgumentError
+    @test occursin("composes the pullback layer by layer", raised.msg)
+end
+
+@testset "a parametrized GHNN: the carried system parameters reach the gradient" begin
+    arch = GeneralizedHamiltonianArchitecture(4; width = 4, nhidden = 1, n_integrators = 1,
+                                              parameters = system_parameters)
+    snn, nn = SymbolicNeuralNetwork(arch), NeuralNetwork(arch, Float64)
+    loss = FeedForwardLoss()
+
+    pullback = SymbolicNeuralNetworks.SymbolicPullback(snn, loss; layerwise = true)
+    @test construction(pullback) == :LayerwiseGradientFunction
+
+    gradient = pullback.fun((input, system_parameters), output, params(nn))(1)
+    reference = Zygote.gradient(params(nn)) do p
+        norm(apply_parametric(nn.model, input, system_parameters, p) - output) / norm(output)
+    end[1]
+    @test maximum_difference(gradient, reference) < 1e-14
+
+    # the monolithic construction cannot be built for this architecture at all: it traces the chain
+    # from a plain vector, and the layers then default the system parameters away, leaving the energy
+    # network's first `Dense` short of the components it reads
+    @test_throws Exception SymbolicNeuralNetworks.SymbolicPullback(snn, loss; layerwise = false)
+end
+
+# `ParametricLoss` is the loss the parameter-dependent architectures train with, and it takes the
+# system parameters as a fifth argument -- so the layerwise construction cannot guess its expression
+# and it declares one instead.
+@testset "ParametricLoss declares its expression, so the sweep can seed it" begin
+    arch = GeneralizedHamiltonianArchitecture(4; width = 4, nhidden = 1, n_integrators = 2,
+                                              parameters = system_parameters)
+    snn, nn = SymbolicNeuralNetwork(arch), NeuralNetwork(arch, Float64)
+    loss = ParametricLoss()
+
+    @test !isnothing(SymbolicNeuralNetworks.loss_expression(loss, [1.0], [1.0]))
+    @test !isnothing(loss_seed(loss, snn))
+
+    pullback = SymbolicNeuralNetworks.SymbolicPullback(snn, loss; layerwise = :auto)
+    @test construction(pullback) == :LayerwiseGradientFunction
+
+    gradient = pullback.fun((input, system_parameters), output, params(nn))(1)
+    reference = Zygote.gradient(p -> loss(nn.model, p, input, output, system_parameters),
+                                params(nn))[1]
+    @test maximum_difference(gradient, reference) < 1e-14
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,6 +49,9 @@ end
 @safetestset "Parametric and forced layers and architectures                                  " begin
     include("generalized_hamiltonian_neural_networks/parametric_layers_and_architectures_test.jl")
 end
+@safetestset "Layerwise symbolic pullback for a PGHNN                                          " begin
+    include("generalized_hamiltonian_neural_networks/layerwise_symbolic_pullback_test.jl")
+end
 @safetestset "Manifold Neural Network Layers                                                  " begin
     include("layers/manifold_layers.jl")
 end


### PR DESCRIPTION
Resolves #245, given [SymbolicNeuralNetworks #56](https://github.com/JuliaGNI/SymbolicNeuralNetworks.jl/pull/56).

> **Base branch.** This targets `pghnn-rebase`, the rebased form of #207's work, because that is where `SymplecticEuler` lives — on `main` the `GeneralizedHamiltonianArchitecture` constructor is still `error("GHNN still has to be implemented!")`. #207 and its branch are untouched.

## What this does

`SymbolicNeuralNetworks` composes the pullback of a chain layer by layer, putting *fresh* symbolic variables between two layers instead of inlining one layer's expression into the next — which is what keeps the symbolic material a sum over layers rather than a product. Its seam was a plain vector, so it assumed every layer maps an array to an array.

A `SymplecticEuler` built with `return_parameters = true` threads the parameters of the system on to the next layer and therefore returns a `Tuple`, which could not be seeded at all. Worse, `composes_layerwise` said the chain decomposes, so `layerwise = :auto` committed to that path and then raised — [SNN #54](https://github.com/JuliaGNI/SymbolicNeuralNetworks.jl/issues/54).

SNN 0.7 widens the seam. `SymplecticEuler` now carries `SymbolicEnergy`'s `parameter_length` and `parameter_layout` — as a *trailing* type parameter, so every existing partial signature goes on matching with the layout left free — and implements the four methods that say how it meets the seam: `carried_variables`, `seam_value`, `state_expressions` and `seam_arguments`. What it carries is data and never a differentiation target: the sensitivity pairs with the state, and the flattened system parameters become one more argument of each generated kernel.

`ParametricLoss` declares its `loss_expression`, so the sweep can seed it. The construction guesses one by applying the loss in its four-argument form, and this loss takes five — without the declaration `loss_seed` would decline and fall back to the construction that cannot build. The declaration restates `_compute_loss`, which is what the functor itself uses.

## Results

```julia
SymbolicNeuralNetworks.SymbolicPullback(SymbolicNeuralNetwork(arch), FeedForwardLoss())
```

| case | before | now |
|---|---|---|
| `n_integrators = 1`, no system parameters | `MethodError` under `:auto` | builds layerwise; 1.4e-16 vs the monolithic path, 8.3e-17 vs `Zygote` |
| `n_integrators = 2` | expression of 10⁹ terms, never finished | 4 steps in ~1.5 s; 7.6e-17 vs `Zygote` |
| parametrized, `ParametricLoss`, 2 integrators | no construction builds | 2.2e-16 vs `Zygote` |

The parametrized row is the one worth dwelling on. The monolithic construction traces the chain from a plain vector, so every layer defaults its system parameters to `NullParameters` and the energy network's first `Dense` is then short of the components it reads; the build dies inside `Symbolics`. The layerwise construction is handed the pair `(state, system parameters)` and differentiates the map that was actually asked for. It is not the faster construction there — it is the only one.

## The tractability limit stays, and now says where to go

`_check_symbolic_pullback_is_tractable` keeps its `n_integrators > 1` refusal, because the two constructors in `src/pullbacks/symbolic_hnn_pullback.jl` still build one expression for the whole network by hand. It also guards `SymbolicPullback(arch)`, which had no guard at all and failed with an obscure `Symbolics` error.

That one cannot move onto the layerwise construction: `HNNLoss` evaluates the pre-built Hamiltonian vector field rather than the chain, so there is no prediction for a layerwise seed to start from. `SymbolicPullback(nn, ::ParametricLoss, system_params)` *can*, and doing so would also retire its concatenation of the system parameters onto the network input — that is #245's remaining half, left for a follow-up.

## Known limitation

The sweep runs the forward pass by *calling* each layer, so it inherits `SymplecticEuler`'s own single-sample restriction — the `@view(…)[:, 1]` in the layer and the `@assert size(qp, 2) == 1` in `concatenate_array_with_parameters`. A batch has to be taken sample by sample, as `apply_parametric` already does. The monolithic construction never calls the layer at run time and so does not have this restriction. Lifting it is layer work, independent of this PR.

## Testing

New `test/generalized_hamiltonian_neural_networks/layerwise_symbolic_pullback_test.jl`, registered in `runtests.jl`. All five GHNN test files pass, including the four that existed before — the struct gained fields and a type parameter, so those are the regression check.

## Blocked on

SymbolicNeuralNetworks 0.7 is not yet registered. Verified locally with that tree `Pkg.develop`ed in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)