### PR TITLE
Normalise all sources to Unicode NFC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,24 +13,6 @@ breaking release).
 > alongside the work. Where a release removed exported names the list is given; where it is a
 > reconstruction of intent, it says so.
 
-## [Unreleased] — Unicode normalisation
-
-### Changed
-
-- Every tracked source file is now Unicode NFC-normalised. Nineteen files across `src/`, `test/`,
-  `scripts/` and `docs/` stored `Ñ` (39 times), `ṗ` (18), `Ũ` (10) and `ȳ` (3) as a base letter plus
-  a combining mark, inherited from macOS rather than chosen.
-
-  Nothing about the compiled code changes: Julia's parser normalises identifiers to NFC, so the
-  symbols were already precomposed and dispatch, field names and method resolution are untouched.
-  No string literal was affected, and no changed line falls inside a `jldoctest` block — the one
-  changed line in a fenced block, `docs/src/tutorials/symplectic_autoencoder.md:65`, is inside an
-  `@example` block, whose output Documenter does not compare. What changes is that the source now
-  matches what a keyboard, an editor search or a `grep` pattern produces; in an NFD file a pattern
-  typed in NFC matches nothing at all, silently.
-
-  Every changed file is exactly the NFC normalisation of its predecessor.
-
 ## [Unreleased] — 0.8.0
 
 > [!NOTE]
@@ -146,6 +128,24 @@ so it cannot coexist with `GeometricOptimizers` 0.5.
   survives although it is not in its storage, that element types are preserved, that the leaves are
   copies rather than the same arrays, and that a whole network keeps its architecture, model and
   backend.
+
+- **Every tracked file is Unicode NFC-normalised.** Nineteen files across `src/`, `test/`,
+  `scripts/` and `docs/` stored `Ñ` (39 times), `ṗ` (18), `Ũ` (10) and `ȳ` (3) as a base letter plus
+  a combining mark, inherited from macOS rather than chosen. `q̇`, `q̈`, `f̄` and `b̄` have no
+  precomposed codepoint and are unchanged.
+
+  Nothing about the compiled code changes: Julia's parser normalises identifiers to NFC, so the
+  symbols were already precomposed and dispatch, field names and method resolution are untouched.
+  No string literal was affected, and no changed line falls inside a `jldoctest` block. Two changed
+  lines do sit in fenced blocks — `docs/src/tutorials/symplectic_autoencoder.md:65` in an
+  `@example` block, and `docs/src/reduced_order_modeling/reduced_order_modeling.md:79` in an
+  `@eval` block, which Documenter does execute. Both are accesses to `GeometricProblems`' `Ñ`,
+  which is defined precomposed there, so both blocks run exactly as before; Documenter compares the
+  output of neither.
+
+  What changes is that the source now matches what a keyboard, an editor search or a `grep` pattern
+  produces; in an NFD file a pattern typed in NFC matches nothing at all, silently. Every changed
+  file is exactly the NFC normalisation of its predecessor.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ breaking release).
 > alongside the work. Where a release removed exported names the list is given; where it is a
 > reconstruction of intent, it says so.
 
+## [Unreleased] — Unicode normalisation
+
+### Changed
+
+- Every tracked source file is now Unicode NFC-normalised. Nineteen files across `src/`, `test/`,
+  `scripts/` and `docs/` stored `Ñ` (39 times), `ṗ` (18), `Ũ` (10) and `ȳ` (3) as a base letter plus
+  a combining mark, inherited from macOS rather than chosen.
+
+  Nothing about the compiled code changes: Julia's parser normalises identifiers to NFC, so the
+  symbols were already precomposed and dispatch, field names and method resolution are untouched.
+  No string literal was affected, and no changed line falls inside a `jldoctest` block — the one
+  changed line in a fenced block, `docs/src/tutorials/symplectic_autoencoder.md:65`, is inside an
+  `@example` block, whose output Documenter does not compare. What changes is that the source now
+  matches what a keyboard, an editor search or a `grep` pattern produces; in an NFD file a pattern
+  typed in NFC matches nothing at all, silently.
+
+  Every changed file is exactly the NFC normalisation of its predecessor.
+
 ## [Unreleased] — 0.8.0
 
 > [!NOTE]

--- a/docs/src/reduced_order_modeling/reduced_order_modeling.md
+++ b/docs/src/reduced_order_modeling/reduced_order_modeling.md
@@ -76,7 +76,7 @@ function make_axis(i)
         ylabelcolor = text_color,
         backgroundcolor = :transparent)
     # plot 6 time steps
-    domain = lw.compute_domain(lw.Ñ + 2)
+    domain = lw.compute_domain(lw.Ñ + 2)
     for time_step in time_steps
         lines!(ax, domain, lw.u₀(domain .- μ * time_step, μ), color = colors[i])
     end

--- a/docs/src/tutorials/symplectic_autoencoder.md
+++ b/docs/src/tutorials/symplectic_autoencoder.md
@@ -62,7 +62,7 @@ where the ``\omega`` is an element of the domain ``\Omega = [-0.5, 0.5].`` For t
 ```@example toda_lattice
 import GeometricProblems.TodaLattice as tl
 
-N = tl.Ñ # hide
+N = tl.Ñ # hide
 Δx = 1. / (N - 1) # hide
 Ω = -0.5 : Δx : 0.5 # hide
 tl.μ

--- a/scripts/Script_using_fully_GML/data_problem.jl
+++ b/scripts/Script_using_fully_GML/data_problem.jl
@@ -244,14 +244,14 @@ function get_multiple_trajectory_structure_with_target(
     Get_p(Data, i, n) = Data.data[Symbol("Trajectory_"*string(i))][:data][n][2]
 
     Get_q̇(Target, i, n) = Target[Symbol("Trajectory_"*string(i))][:target][n][1][1]
-    Get_ṗ(Target, i, n) = Target[Symbol("Trajectory_"*string(i))][:target][n][2][1]
+    Get_ṗ(Target, i, n) = Target[Symbol("Trajectory_"*string(i))][:target][n][2][1]
 
     return dataTarget(
         data_trajectory(
             data, Get_nb_trajectory, Get_length_trajectory, Get_q, Get_p, Get_Δt),
         Target,
         Get_q̇,
-        Get_ṗ)
+        Get_ṗ)
 end
 
 function get_multiple_trajectory_structure_Lagrangian(

--- a/scripts/Script_using_fully_GML/hnn_script.jl
+++ b/scripts/Script_using_fully_GML/hnn_script.jl
@@ -13,7 +13,7 @@ Get_Data = Dict(
     :q => (Data, n) -> Data[1][n][1],
     :p => (Data, n) -> Data[1][n][2],
     :q̇ => (Data, n) -> Data[2][n][1],
-    :ṗ => (Data, n) -> Data[2][n][2]
+    :ṗ => (Data, n) -> Data[2][n][2]
 )
 data = TrainingData(Data, Get_Data)
 

--- a/scripts/symplectic_autoencoders/initial_condition.jl
+++ b/scripts/symplectic_autoencoders/initial_condition.jl
@@ -55,20 +55,20 @@ end
 """
 If you call this function with a Float and an Integer, then the integer will be interpreted as the number of nodes, i.e. degrees of freedom.
 """
-function get_initial_condition(μ::T, Ñ::Integer) where {T}
-    get_initial_condition(μ, T(1/(Ñ+1)))
+function get_initial_condition(μ::T, Ñ::Integer) where {T}
+    get_initial_condition(μ, T(1/(Ñ+1)))
 end
 
-function get_initial_condition2(μ::T, Ñ::Integer) where {T}
-    get_initial_condition2(μ, T(1/(Ñ+1)))
+function get_initial_condition2(μ::T, Ñ::Integer) where {T}
+    get_initial_condition2(μ, T(1/(Ñ+1)))
 end
 
-function get_initial_condition_vector(μ::T, Ñ::Integer) where {T}
-    ics_offset = get_initial_condition(μ, Ñ)
+function get_initial_condition_vector(μ::T, Ñ::Integer) where {T}
+    ics_offset = get_initial_condition(μ, Ñ)
     vcat(ics_offset.q.parent, ics_offset.p.parent)
 end
 
-function get_initial_condition_vector2(μ::T, Ñ::Integer) where {T}
-    ics_offset = get_initial_condition2(μ, Ñ)
+function get_initial_condition_vector2(μ::T, Ñ::Integer) where {T}
+    ics_offset = get_initial_condition2(μ, Ñ)
     vcat(ics_offset.q.parent, ics_offset.p.parent)
 end

--- a/scripts/symplectic_autoencoders/integration.jl
+++ b/scripts/symplectic_autoencoders/integration.jl
@@ -8,7 +8,7 @@ using HDF5
 include("vector_fields.jl")
 include("initial_condition.jl")
 
-Ñ = 128
+Ñ = 128
 T = Float64
 # params = (μ=T(.5), N=N, Δx=T(1/(N-1)))
 n_params = 20
@@ -21,19 +21,19 @@ p_zero = false
 function perform_integration(params, n_time_steps)
     timespan = (T(0), T(1))
     timestep = T((timespan[2] - timespan[1])/(n_time_steps-1))
-    ics_offset = p_zero ? get_initial_condition2(params.μ, params.Ñ) :
-                 get_initial_condition(params.μ, params.Ñ)
+    ics_offset = p_zero ? get_initial_condition2(params.μ, params.Ñ) :
+                 get_initial_condition(params.μ, params.Ñ)
     ics = (q = ics_offset.q.parent, p = ics_offset.p.parent)
     ode = HODEProblem(
         v_f_hamiltonian(params)..., parameters = params, timespan, timestep, ics)
     sol = integrate(ode, ImplicitMidpoint())
 end
 
-function perform_multiple_integration(ℙ, n_time_steps, Ñ = Ñ)
+function perform_multiple_integration(ℙ, n_time_steps, Ñ = Ñ)
     sols = ()
     for μ in ℙ
         print("Now performing integration for μ="*string(μ)*"\n")
-        params = (μ = μ, Ñ = Ñ, Δx = T(1/(Ñ-1)))
+        params = (μ = μ, Ñ = Ñ, Δx = T(1/(Ñ-1)))
         sols = (sols..., perform_integration(params, n_time_steps))
     end
     sys_dim = length(sols[1].q[0])
@@ -47,18 +47,18 @@ function perform_multiple_integration(ℙ, n_time_steps, Ñ = Ñ)
 end
 
 function generate_and_safe_data(
-        ℙ, n_time_steps, Ñ = Ñ, n_params = n_params, file_name = "snapshot_matrix.h5")
+        ℙ, n_time_steps, Ñ = Ñ, n_params = n_params, file_name = "snapshot_matrix.h5")
     h5open(file_name, "w") do h5
-        h5["data"] = perform_multiple_integration(ℙ, n_time_steps, Ñ)
+        h5["data"] = perform_multiple_integration(ℙ, n_time_steps, Ñ)
         h5["n_params"] = n_params
     end
 end
 
 function generate_and_safe_data(;
         n_params::Integer = n_params, n_time_steps = n_time_steps,
-        Ñ = Ñ, file_name = "snapshot_matrix.h5")
+        Ñ = Ñ, file_name = "snapshot_matrix.h5")
     ℙ = T(μ_left):T((μ_right - μ_left) / (n_params - 1)):T(μ_right)
-    generate_and_safe_data(ℙ, n_time_steps, Ñ, n_params, file_name)
+    generate_and_safe_data(ℙ, n_time_steps, Ñ, n_params, file_name)
 end
 
 p_zero ? generate_and_safe_data(file_name = "snapshot_matrix2.h5") :

--- a/scripts/symplectic_autoencoders/training.jl
+++ b/scripts/symplectic_autoencoders/training.jl
@@ -122,13 +122,13 @@ function get_nn_encoder_decoder(;
     nn_encoder, nn_decoder
 end
 
-function get_reduced_model(encoder, decoder; n = 5, μ_val = 0.51, Ñ = (N-2),
+function get_reduced_model(encoder, decoder; n = 5, μ_val = 0.51, Ñ = (N-2),
         n_time_steps = n_time_steps, integrator = ImplicitMidpoint(),
         system_type = GeometricMachineLearning.Symplectic())
-    params = (μ = μ_val, Ñ = Ñ, Δx = T(1/(Ñ-1)))
+    params = (μ = μ_val, Ñ = Ñ, Δx = T(1/(Ñ-1)))
     timestep = T(1/(n_time_steps-1))
     timespan = (T(0), T(1))
-    ics = get_initial_condition_vector(μ_val, Ñ)
+    ics = get_initial_condition_vector(μ_val, Ñ)
     v_field_full = v_field(params)
     v_field_reduced = reduced_vector_field_from_full_explicit_vector_field(
         v_field_explicit(params), decoder, N, n)
@@ -199,7 +199,7 @@ encoders_decoders = get_enocders_decoders(n_range)
 
 μ_errors = NamedTuple()
 for μ_test_val in μ_range
-    dummy_rs = get_reduced_model(nothing, nothing; n = 1, μ_val = μ_test_val, Ñ = (N-2))
+    dummy_rs = get_reduced_model(nothing, nothing; n = 1, μ_val = μ_test_val, Ñ = (N-2))
     sol_full = perform_integration_full(dummy_rs)
     errors = NamedTuple()
     for n in n_range
@@ -210,9 +210,9 @@ for μ_test_val in μ_range
         nn_encoder, nn_decoder = encoders_decoders_current.nn
 
         psd_rs = get_reduced_model(
-            psd_encoder, psd_decoder; n = n, μ_val = μ_test_val, Ñ = (N-2))
+            psd_encoder, psd_decoder; n = n, μ_val = μ_test_val, Ñ = (N-2))
         nn_rs = get_reduced_model(
-            nn_encoder, nn_decoder; n = n, μ_val = μ_test_val, Ñ = (N-2))
+            nn_encoder, nn_decoder; n = n, μ_val = μ_test_val, Ñ = (N-2))
 
         reduction_errors = (psd = compute_reduction_error(psd_rs, sol_full),
             nn = compute_reduction_error(nn_rs, sol_full))

--- a/scripts/symplectic_autoencoders/vector_fields.jl
+++ b/scripts/symplectic_autoencoders/vector_fields.jl
@@ -8,7 +8,7 @@ _mul(q₁::OffsetVector, A::OffsetMatrix, q₂::OffsetVector) = q₁.parent'*A.p
 _mul(p₁::OffsetVector, p₂::OffsetVector) = p₁.parent'*p₂.parent
 
 function v_f_hamiltonian(params)
-    K = assemble_matrix(params.μ, params.Δx, params.Ñ)
+    K = assemble_matrix(params.μ, params.Δx, params.Ñ)
     function f(f, t, q, p, params)
         #f .= -(_mul(K + OffsetArray(K.parent', OffsetArrays.Origin(0)), q))
         f .= - (K.parent + K.parent') * q / params.Δx
@@ -23,7 +23,7 @@ function v_f_hamiltonian(params)
 end
 
 function v_field(params)
-    K = assemble_matrix(params.μ, params.Δx, params.Ñ).parent
+    K = assemble_matrix(params.μ, params.Δx, params.Ñ).parent
     full_mat = hcat(vcat(K + K', zero(K)), vcat(zero(K), one(K)*params.Δx))
     𝕁N = PoissonTensor(size(K, 1))
     function v(v, t, q, params)
@@ -33,7 +33,7 @@ function v_field(params)
 end
 
 function v_field_explicit(params)
-    K = assemble_matrix(params.μ, params.Δx, params.Ñ).parent
+    K = assemble_matrix(params.μ, params.Δx, params.Ñ).parent
     full_mat = hcat(vcat(K + K', zero(K)), vcat(zero(K), one(K)*params.Δx))
     𝕁N = PoissonTensor(size(K, 1))
     function v(t, q, params)

--- a/scripts/test/data_generation.jl
+++ b/scripts/test/data_generation.jl
@@ -79,7 +79,7 @@ get_Data = Dict(
     :q => (Data, n) -> Data[1][n],
     :p => (Data, n) -> Data[2][n],
     :q̇ => (Data, n) -> Data[3][n],
-    :ṗ => (Data, n) -> Data[4][n]
+    :ṗ => (Data, n) -> Data[4][n]
 )
 sam_dps_data = TrainingData(Data, get_Data)
 
@@ -93,6 +93,6 @@ get_Data = Dict(
     :q => (Data, i, n) -> Data[Symbol("Trajectory"*string(i))][1][n],
     :p => (Data, i, n) -> Data[Symbol("Trajectory"*string(i))][2][n],
     :q̇ => (Data, i, n) -> Data[Symbol("Trajectory"*string(i))][3][n],
-    :ṗ => (Data, i, n) -> Data[Symbol("Trajectory"*string(i))][4][n]
+    :ṗ => (Data, i, n) -> Data[Symbol("Trajectory"*string(i))][4][n]
 )
 tra_dps_data = TrainingData(Data, get_Data)

--- a/scripts/test/test_data.jl
+++ b/scripts/test/test_data.jl
@@ -7,7 +7,7 @@ using Test
 
 keys1 = (:q,)
 keys2 = (:q, :p)
-keys3 = (:q, :p, :q̇, :ṗ)
+keys3 = (:q, :p, :q̇, :ṗ)
 keys4 = (:q, :q̇)
 keys5 = (:q, :q̇, :q̈)
 keys6 = (:q, :p, :s)
@@ -24,7 +24,7 @@ keys6 = (:q, :p, :s)
 @test can_reduce(DataSymbol(keys5), DataSymbol(keys2)) == false
 
 @test symboldiff(DataSymbol(keys2), DataSymbol(keys1)) == (:p,)
-@test symboldiff(DataSymbol(keys3), DataSymbol(keys1)) == (:p, :q̇, :ṗ)
+@test symboldiff(DataSymbol(keys3), DataSymbol(keys1)) == (:p, :q̇, :ṗ)
 
 #########################################
 # Test for DataTraining

--- a/src/data/data_symbol.jl
+++ b/src/data/data_symbol.jl
@@ -16,7 +16,7 @@ type(::DataSymbol{T}) where {T <: AbstractDataSymbol} = T
 symbols(::DataSymbol{AbstractDataSymbol}) = nothing
 symbols(::DataSymbol{PositionSymbol}) = (:q,)
 symbols(::DataSymbol{PhaseSpaceSymbol}) = (:q, :p)
-symbols(::DataSymbol{DerivativePhaseSpaceSymbol}) = (:q, :p, :q̇, :ṗ)
+symbols(::DataSymbol{DerivativePhaseSpaceSymbol}) = (:q, :p, :q̇, :ṗ)
 symbols(::DataSymbol{PosVeloSymbol}) = (:q, :q̇)
 symbols(::DataSymbol{PosVeloAccSymbol}) = (:q, :q̇, :q̈)
 

--- a/src/data_loader/data_loader.jl
+++ b/src/data_loader/data_loader.jl
@@ -258,7 +258,7 @@ function data_tensors_from_geometric_solution(solution::GeometricSolution{T,
         T2,
         TT,
         NT}) where {T <: Number, T2 <: Number, TT <: TimeSeries{T2},
-        TuT, NT <: NamedTuple{(:t, :q, :p, :q̇, :ṗ), TuT}}
+        TuT, NT <: NamedTuple{(:t, :q, :p, :q̇, :ṗ), TuT}}
     sys_dim, input_time_steps = length(solution.dataser.q[0]), length(solution.t)
     data = (q = zeros(T, sys_dim, input_time_steps, 1),
         p = zeros(T, sys_dim, input_time_steps, 1))
@@ -312,7 +312,7 @@ function DataLoader(solution::GeometricSolution{T, T2, TT, NT},
         TT <: TimeSeries{T2},
         TuT,
         NT <: Union{
-            NamedTuple{(:t, :q, :p, :q̇, :ṗ), TuT},
+            NamedTuple{(:t, :q, :p, :q̇, :ṗ), TuT},
             NamedTuple{(:t, :q, :v), TuT},
             NamedTuple{(:t, :q, :q̇), TuT}}}
     data = data_tensors_from_geometric_solution(solution)
@@ -371,7 +371,7 @@ function DataLoader(ensemble_solution::EnsembleSolution{T, T1, Vector{ST}};
         T1,
         TuT,
         TT <: TimeSeries{T1},
-        ST <: GeometricSolution{T, T1, TT, NamedTuple{(:t, :q, :p, :q̇, :ṗ), TuT}}
+        ST <: GeometricSolution{T, T1, TT, NamedTuple{(:t, :q, :p, :q̇, :ṗ), TuT}}
 }
     sys_dim = length(ensemble_solution.s[1].q[0])
     input_time_steps = length(ensemble_solution.t)

--- a/src/training_method/hnn_exact_method.jl
+++ b/src/training_method/hnn_exact_method.jl
@@ -6,9 +6,9 @@ end
 
 function loss_single(
         ::TrainingMethod{HnnExactMethod}, nn::NeuralNetwork{<:HamiltonianArchitecture},
-        qₙ, pₙ, q̇ₙ, ṗₙ, params = params(nn))
+        qₙ, pₙ, q̇ₙ, ṗₙ, params = params(nn))
     dH = vectorfield(nn, [qₙ..., pₙ...], params)
-    sqeuclidean(dH[1], q̇ₙ) + sqeuclidean(dH[2], ṗₙ)
+    sqeuclidean(dH[1], q̇ₙ) + sqeuclidean(dH[2], ṗₙ)
 end
 
 function get_loss(::TrainingMethod{HnnExactMethod},
@@ -17,7 +17,7 @@ function get_loss(::TrainingMethod{HnnExactMethod},
     (Zygote.ignore_derivatives(get_data(data, :q, args...)),
         Zygote.ignore_derivatives(get_data(data, :p, args...)),
         Zygote.ignore_derivatives(get_data(data, :q̇, args...)),
-        Zygote.ignore_derivatives(get_data(data, :ṗ, args...)))
+        Zygote.ignore_derivatives(get_data(data, :ṗ, args...)))
 end
 
 function loss(

--- a/test/custom_ad_rules/matrix_vector_multiplication.jl
+++ b/test/custom_ad_rules/matrix_vector_multiplication.jl
@@ -13,10 +13,10 @@ end
 #the @thunk macro means that the computation is only performed in case it is needed
 function ChainRulesCore.rrule(::typeof(foo_mul), foo::Foo{T}, b::AbstractArray) where {T}
     y = foo_mul(foo, b)
-    function foo_mul_pullback(ȳ)
+    function foo_mul_pullback(ȳ)
         f̄ = NoTangent()
-        f̄oo = @thunk Tangent{Foo{T}}(; A = ȳ * b', c = ZeroTangent())
-        b̄ = @thunk foo.A' * ȳ
+        f̄oo = @thunk Tangent{Foo{T}}(; A = ȳ * b', c = ZeroTangent())
+        b̄ = @thunk foo.A' * ȳ
         return f̄, f̄oo, b̄
     end
     return y, foo_mul_pullback

--- a/test/data/data_generation.jl
+++ b/test/data/data_generation.jl
@@ -79,7 +79,7 @@ get_Data = Dict(
     :q => (Data, n) -> Data[1][n],
     :p => (Data, n) -> Data[2][n],
     :q̇ => (Data, n) -> Data[3][n],
-    :ṗ => (Data, n) -> Data[4][n]
+    :ṗ => (Data, n) -> Data[4][n]
 )
 sam_dps_data = TrainingData(Data, get_Data)
 
@@ -93,6 +93,6 @@ get_Data = Dict(
     :q => (Data, i, n) -> Data[Symbol("Trajectory"*string(i))][1][n],
     :p => (Data, i, n) -> Data[Symbol("Trajectory"*string(i))][2][n],
     :q̇ => (Data, i, n) -> Data[Symbol("Trajectory"*string(i))][3][n],
-    :ṗ => (Data, i, n) -> Data[Symbol("Trajectory"*string(i))][4][n]
+    :ṗ => (Data, i, n) -> Data[Symbol("Trajectory"*string(i))][4][n]
 )
 tra_dps_data = TrainingData(Data, get_Data)

--- a/test/data/test_data.jl
+++ b/test/data/test_data.jl
@@ -7,7 +7,7 @@ using Test
 
 keys1 = (:q,)
 keys2 = (:q, :p)
-keys3 = (:q, :p, :q̇, :ṗ)
+keys3 = (:q, :p, :q̇, :ṗ)
 keys4 = (:q, :q̇)
 keys5 = (:q, :q̇, :q̈)
 keys6 = (:q, :p, :s)
@@ -24,7 +24,7 @@ keys6 = (:q, :p, :s)
 @test can_reduce(DataSymbol(keys5), DataSymbol(keys2)) == false
 
 @test symboldiff(DataSymbol(keys2), DataSymbol(keys1)) == (:p,)
-@test symboldiff(DataSymbol(keys3), DataSymbol(keys1)) == (:p, :q̇, :ṗ)
+@test symboldiff(DataSymbol(keys3), DataSymbol(keys1)) == (:p, :q̇, :ṗ)
 
 #########################################
 # Test for DataTraining

--- a/test/optimizers/optimizer_convergence_tests/psd_optim.jl
+++ b/test/optimizers/optimizer_convergence_tests/psd_optim.jl
@@ -49,17 +49,17 @@ function svd_test(A, n, train_steps = 1000, tol = 1e-1; retraction = cayley)
     o₂ = Optimizer(MomentumMethod(), ps; retraction = retraction, step_size = 0.01)
     o₃ = Optimizer(Adam(), ps; retraction = retraction, step_size = 0.01)
 
-    U₁, Ũ₁, err₁ = train_network!(o₁, model, deepcopy(ps), A, train_steps, tol)
-    U₂, Ũ₂, err₂ = train_network!(o₂, model, deepcopy(ps), A, train_steps, tol)
-    U₃, Ũ₃, err₃ = train_network!(o₃, model, deepcopy(ps), A, train_steps, tol)
+    U₁, Ũ₁, err₁ = train_network!(o₁, model, deepcopy(ps), A, train_steps, tol)
+    U₂, Ũ₂, err₂ = train_network!(o₂, model, deepcopy(ps), A, train_steps, tol)
+    U₃, Ũ₃, err₃ = train_network!(o₃, model, deepcopy(ps), A, train_steps, tol)
 
     @test check(U₁) < tol
-    @test check(Ũ₁) < tol
+    @test check(Ũ₁) < tol
     @test norm((err₁ - err_best)/err_best) < tol
     @test check(U₂) < tol
     @test norm((err₂ - err_best)/err_best) < tol
     @test check(U₃) < tol
-    @test check(Ũ₃) < tol
+    @test check(Ũ₃) < tol
     @test norm((err₃ - err_best)/err_best) < tol
 end
 

--- a/test/optimizers/optimizer_convergence_tests/svd_optim.jl
+++ b/test/optimizers/optimizer_convergence_tests/svd_optim.jl
@@ -45,17 +45,17 @@ function svd_test(A, n, train_steps = 1000, tol = 1e-1; retraction = cayley)
     o₂ = Optimizer(MomentumMethod(), ps; retraction = retraction, step_size = 0.01)
     o₃ = Optimizer(Adam(), ps; retraction = retraction, step_size = 0.01)
 
-    U₁, Ũ₁, err₁ = train_network!(o₁, model, deepcopy(ps), A, train_steps, tol)
-    U₂, Ũ₂, err₂ = train_network!(o₂, model, deepcopy(ps), A, train_steps, tol)
-    U₃, Ũ₃, err₃ = train_network!(o₃, model, deepcopy(ps), A, train_steps, tol)
+    U₁, Ũ₁, err₁ = train_network!(o₁, model, deepcopy(ps), A, train_steps, tol)
+    U₂, Ũ₂, err₂ = train_network!(o₂, model, deepcopy(ps), A, train_steps, tol)
+    U₃, Ũ₃, err₃ = train_network!(o₃, model, deepcopy(ps), A, train_steps, tol)
 
     @test check(U₁) < tol
-    @test check(Ũ₁) < tol
+    @test check(Ũ₁) < tol
     @test norm((err₁ - err_best)/err_best) < tol
     @test check(U₂) < tol
     @test norm((err₂ - err_best)/err_best) < tol
     @test check(U₃) < tol
-    @test check(Ũ₃) < tol
+    @test check(Ũ₃) < tol
     @test norm((err₃ - err_best)/err_best) < tol
 end
 

--- a/test/symplectic_autoencoders/linear_wave_equation.jl
+++ b/test/symplectic_autoencoders/linear_wave_equation.jl
@@ -4,13 +4,13 @@ include("../../scripts/symplectic_autoencoders/assemble_matrix.jl")
 
 μ = 0.5
 Δx = 0.1
-Ñ = 2048
+Ñ = 2048
 
 K = assemble_matrix(μ, Δx)
 
-function H₁(q, μ, Δx, Ñ = length(q)-2)
+function H₁(q, μ, Δx, Ñ = length(q)-2)
     H_val = 0
-    for i in 1:Ñ
+    for i in 1:Ñ
         H_val += μ^2 / (2 * Δx) *
                  (q[i]*(q[i] - q[i - 1] - q[i + 1]) + (q[i - 1]^2 + q[i + 1]^2) / 2)
     end
@@ -19,5 +19,5 @@ end
 
 _mul(q₁::OffsetVector, A::OffsetMatrix, q₂::OffsetVector) = q₁.parent'*A.parent*q₂.parent
 
-q_vec = OffsetArray(rand(Ñ+2), OffsetArrays.Origin(0))
+q_vec = OffsetArray(rand(Ñ+2), OffsetArrays.Origin(0))
 @test isapprox(H₁(q_vec, μ, Δx), _mul(q_vec, K, q_vec))


### PR DESCRIPTION
Converts nineteen files across `src/`, `test/`, `scripts/` and `docs/` from NFD to Unicode NFC. They stored `Ñ` (39×), `ṗ` (18), `Ũ` (10) and `ȳ` (3) as a base letter plus a combining mark — an artefact of macOS, not a decision.

Part of a tree-wide conversion (`Tasks/Normalise the Julia sources to NFC.md`).

## Why

Julia's parser normalises identifiers to NFC, so the compiled symbols were already precomposed and dispatch, field names and method resolution are untouched. The cost of NFD is entirely in tooling: **a pattern typed in NFC matches nothing at all in an NFD file, silently.**

`q̇`, `q̈`, `f̄` and `b̄` have no precomposed codepoint and are unchanged — the invariant is `s == Unicode.normalize(s, :NFC)`, not the absence of combining marks.

## How to review

Every changed file is byte-equal to the NFC normalisation of its predecessor, and **all 17 changed `.jl` files have identical `Meta.parseall` `Expr` trees**. No string literal changes at all.

## Documentation

No changed line falls inside a `jldoctest` block. The only changed `src/` file that has doctests is `src/data_loader/data_loader.jl`, whose blocks are at lines 23–45, 79–94 and 98–111 while its changed lines are 261, 315 and 374.

Two changed lines do sit in fenced blocks:

- `docs/src/tutorials/symplectic_autoencoder.md:65`, inside ` ```@example toda_lattice `
- `docs/src/reduced_order_modeling/reduced_order_modeling.md:79`, inside an ` ```@eval ` block — which Documenter **does** execute

Both are attribute accesses on `GeometricProblems`' `Ñ`, which is defined precomposed there (`toda_lattice.jl:135`, `linear_wave.jl:44`), so both blocks run exactly as before. Documenter compares the output of neither.

## Verification

| what | result |
|:--|:--|
| diff is exactly the NFC normalisation | 19/19 files |
| `Meta.parseall` trees, base vs head | identical, 17/17 `.jl` files |
| `Pkg.test()` | **3766 passed, 0 failed** across 59 testsets |
| glyph counts | all four exact, and the list is complete |
| non-NFC tracked files remaining | **0 of 454** |
| no string literal affected | confirmed by the tree comparison |
| `fatou lint` | no finding on any changed line |

**Not applicable** rather than unmeasured: piracy, inference, allocations — identical parse trees, no literal altered.

## Pre-PR verification

Two defects in my changelog entry were found and fixed in a follow-up commit:

- The entry opened a **second `## [Unreleased]` heading** directly above the existing one, leaving two sections carrying the same label. The bullet now lives in that section's `### Changed` list.
- It said "the one changed line in a fenced block". There are **two**, and the second is in an `@eval` block, which Documenter executes — so both the count and the fence type were wrong.

## Pre-existing, deliberately not addressed

`unused-binding` on `Ũ₂` at `test/optimizers/optimizer_convergence_tests/psd_optim.jl:53` and `svd_optim.jl:49` — present identically on `main`.
